### PR TITLE
Authentication with AWS roles instead of credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ aws_secret_access_key = [SECRET ACCESS KEY]
 
 Then this gem will use [AWS Shared Credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) with your credentials file. However, if you'd like to run these through either a default profile in your credentials file or through [User Roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html), then use the flag `aws_roles`:
 
-$ sport_ngin_aws_auditor --with_roles [command] account1
+    $ sport_ngin_aws_auditor --with_roles [command] account1
 
 ### Google Setup (optional)
 You can export audit information to a Google Spreadsheet, but you must first follow “Create a client ID and client secret” on [this page](https://developers.google.com/drive/web/auth/web-server) to get a client ID and client secret for OAuth. Then create a `.google.yml` in your home directory with the following structure.
@@ -88,7 +88,7 @@ slack:
 
 The default is for the file to be called `.aws_auditor.yml` in your home directory, but to pass in a different path, feel free to pass it in via command line like this:
 
-$ sport_ngin_aws-auditor --config="/PATH/TO/FILE/slack_file_creds.yml" audit --slack staging
+    $ sport_ngin_aws-auditor --config="/PATH/TO/FILE/slack_file_creds.yml" audit --slack staging
 
 The webhook urls for slack can be obtained [here](https://api.slack.com/incoming-webhooks).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 ## How-to
 
 ### AWS Setup
-Create an `~/.aws/credentials` file that should have the following structure:
+Either create an `~/.aws/credentials` file that should have the following structure:
 
 ```
 [ACCOUNT 1]
@@ -36,6 +36,10 @@ aws_secret_access_key = [SECRET ACCESS KEY]
 aws_access_key_id = [AWS ACCESS KEY]
 aws_secret_access_key = [SECRET ACCESS KEY]
 ```
+
+Then this gem will use [AWS Shared Credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) with your credentials file. However, if you'd like to run these through either a default profile in your credentials file or through [User Roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html), then use the flag `aws_roles`:
+
+$ sport_ngin_aws_auditor --with_roles [command] account1
 
 ### Google Setup (optional)
 You can export audit information to a Google Spreadsheet, but you must first follow “Create a client ID and client secret” on [this page](https://developers.google.com/drive/web/auth/web-server) to get a client ID and client secret for OAuth. Then create a `.google.yml` in your home directory with the following structure.
@@ -72,7 +76,7 @@ To print a condensed version of the discrepancies to a Slack account (instead of
 
     $ sport_ngin_aws_auditor audit --slack account1
 
-For this option to use a designated channel, username, icon/emoji, and webhook, set up a global config file (called `.aws_auditor.yml`) in your home directory. The webhook urls for slack can be obtained [here](https://api.slack.com/incoming-webhooks). The config file should look something like this:
+For this option to use a designated channel, username, icon/emoji, and webhook, set up a global config file that should look like this:
 
 ```
 slack:
@@ -81,6 +85,12 @@ slack:
   channel: "#[AN SUPER COOL CHANNEL]"
   webhook: [YOUR WEBHOOK URL]
 ```
+
+The default is for the file to be called `.aws_auditor.yml` in your home directory, but to pass in a different path, feel free to pass it in via command line like this:
+
+$ sport_ngin_aws-auditor --config="/PATH/TO/FILE/slack_file_creds.yml" audit --slack staging
+
+The webhook urls for slack can be obtained [here](https://api.slack.com/incoming-webhooks).
 
 ### The Inspect Command
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ aws_secret_access_key = [SECRET ACCESS KEY]
 
 Then this gem will use [AWS Shared Credentials](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) with your credentials file. However, if you'd like to run these through either a default profile in your credentials file or through [User Roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html), then use the flag `aws_roles`:
 
-    $ sport_ngin_aws_auditor --with_roles [command] account1
+    $ sport_ngin_aws_auditor --aws_roles [command] account1
 
 ### Google Setup (optional)
 You can export audit information to a Google Spreadsheet, but you must first follow “Create a client ID and client secret” on [this page](https://developers.google.com/drive/web/auth/web-server) to get a client ID and client secret for OAuth. Then create a `.google.yml` in your home directory with the following structure.

--- a/bin/sport-ngin-aws-auditor
+++ b/bin/sport-ngin-aws-auditor
@@ -11,6 +11,7 @@ version SportNginAwsAuditor::VERSION
 wrap_help_text :verbatim
 
 flag [:config], :desc => 'SportNginAwsAuditor config file path', :default_value => SportNginAwsAuditor::DefaultPaths.config
+switch [:aws_roles], :desc => 'Use AWS roles instead of an ~/.aws/credentials file'
 
 program_long_desc """
 DOCUMENTATION

--- a/lib/sport_ngin_aws_auditor/aws.rb
+++ b/lib/sport_ngin_aws_auditor/aws.rb
@@ -40,5 +40,9 @@ module SportNginAwsAuditor
                                        serial_number: mfa_serial_number,
                                        token_code: mfa_token)
     end
+
+    def self.authenticate_with_roles(environment)
+        Aws.config.update({region: 'us-east-1'})
+    end
   end
 end

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -12,6 +12,6 @@ command 'audit' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/audit'
     raise ArgumentError, 'You must specify an AWS account' unless args.first
-    SportNginAwsAuditor::Scripts::Audit.execute(args.first, options)
+    SportNginAwsAuditor::Scripts::Audit.execute(args.first, options, global_options)
   end
 end

--- a/lib/sport_ngin_aws_auditor/commands/export.rb
+++ b/lib/sport_ngin_aws_auditor/commands/export.rb
@@ -6,6 +6,6 @@ command 'export' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/export'
     raise ArgumentError, 'You must specify an AWS account' unless args.first
-    SportNginAwsAuditor::Scripts::Export.execute(args.first, options)
+    SportNginAwsAuditor::Scripts::Export.execute(args.first, options, global_options)
   end
 end

--- a/lib/sport_ngin_aws_auditor/commands/inspect.rb
+++ b/lib/sport_ngin_aws_auditor/commands/inspect.rb
@@ -7,6 +7,6 @@ command 'inspect' do |c|
   c.action do |global_options, options, args|
     require_relative '../scripts/inspect'
     raise ArgumentError, 'You must specify an AWS account' unless args.first
-    SportNginAwsAuditor::Scripts::Inspect.execute(args.first,options)
+    SportNginAwsAuditor::Scripts::Inspect.execute(args.first,options, global_options)
   end
 end

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -7,8 +7,12 @@ module SportNginAwsAuditor
   module AWSWrapper
     attr_accessor :aws, :account_id
 
-    def aws(environment)
-      SportNginAwsAuditor::AWSSDK.authenticate(environment)
+    def aws(environment, roles)
+      if roles
+        SportNginAwsAuditor::AWSSDK.authenticate_with_roles(environment)
+      else
+        SportNginAwsAuditor::AWSSDK.authenticate(environment)
+      end
     end
 
     def get_account_id

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -10,8 +10,8 @@ module SportNginAwsAuditor
         attr_accessor :options
       end
 
-      def self.execute(environment, options=nil)
-        aws(environment)
+      def self.execute(environment, options=nil, global_options=nil)
+        aws(environment, global_options[:aws_roles])
         @options = options
         slack = options[:slack]
         no_selection = !(options[:ec2] || options[:rds] || options[:cache])

--- a/lib/sport_ngin_aws_auditor/scripts/export.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/export.rb
@@ -13,10 +13,10 @@ module SportNginAwsAuditor
 
       CLASS_TYPES = %w[EC2Instance RDSInstance CacheInstance]
 
-      def self.execute(environment, options = nil)
+      def self.execute(environment, options = nil, global_options = nil)
         @environment = environment
         (puts "Must specify either --drive or --csv"; exit) unless options[:csv] || options[:drive]
-        aws(environment)
+        aws(environment, global_options[:aws_roles])
         print "Gathering info, please wait..."
         all_keys = get_all_keys
         all_info = prepare

--- a/lib/sport_ngin_aws_auditor/scripts/inspect.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/inspect.rb
@@ -4,8 +4,8 @@ module SportNginAwsAuditor
       extend AWSWrapper
       extend OpsWorksWrapper
 
-      def self.execute(environment, options=nil)
-        aws(environment)
+      def self.execute(environment, options=nil, global_options=nil)
+        aws(environment, global_options[:aws_roles])
         no_selection = options.values.uniq == [false]
         output("EC2Instance") if options[:ec2] || no_selection
         output("RDSInstance") if options[:rds] || no_selection 

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -2,7 +2,7 @@ require "sport_ngin_aws_auditor"
 
 module SportNginAwsAuditor
   describe AWSSDK do
-    context 'without mfa' do
+    context 'without mfa without roles' do
       before :each do
         mfa_devices = double('mfa_devices', mfa_devices: [])
         iam_client = double('iam_client', list_mfa_devices: mfa_devices)
@@ -22,7 +22,7 @@ module SportNginAwsAuditor
       end
     end
 
-    context 'with mfa' do
+    context 'with mfa without roles' do
       it "should use MFA if it should" do
         shared_credentials = double('shared_credentials', access_key_id: 'access_key_id',
                                                           secret_access_key: 'secret_access_key')
@@ -42,6 +42,13 @@ module SportNginAwsAuditor
         expect(Aws::Credentials).to receive(:new).and_return(cred_double).at_least(:once)
         expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
         AWSSDK::authenticate('staging')
+      end
+    end
+
+    context 'without mfa with roles' do
+      it "should update configs" do
+        expect(Aws.config).to receive(:update).with({region: 'us-east-1'})
+        AWSSDK::authenticate_with_roles('staging')
       end
     end
   end


### PR DESCRIPTION
Description and Impact
----------------------
Provides an option for authentication through AWS roles instead of through an ~/.aws/credentials file through a new flag `:with_roles`.

Deploy Plan
-----------
- [ ] checkout master
- [ ] `op accept-pull 7`
- [ ] `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Test out the command as normal
- [ ] Test out the command with a default profile when using the new flag
- [ ] Test out the command without a default profile when using the new flag
