### PR TITLE
Proper recognition of windows/linux/vpc instances

### DIFF
--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -41,7 +41,7 @@ module SportNginAwsAuditor
     end
 
     def to_s
-      "#{engine} #{instance_type}"
+      "#{engine.capitalize} #{instance_type}"
     end
 
     def self.get_instances(tag_name=nil)

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -16,13 +16,13 @@ module SportNginAwsAuditor
         self.id = rds_instance.reserved_db_instances_offering_id
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
-        self.engine = rds_instance.product_description
+        self.engine = engine_helper(rds_instance.product_description)
         self.count = 1
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
-        self.engine = rds_instance.engine
+        self.engine = engine_helper(rds_instance.engine)
         self.count = 1
 
         if tag_name
@@ -41,7 +41,7 @@ module SportNginAwsAuditor
     end
 
     def to_s
-      "#{engine_helper} #{multi_az} #{instance_type}"
+      "#{engine} #{multi_az} #{instance_type}"
     end
 
     def self.get_instances(tag_name=nil)
@@ -65,7 +65,7 @@ module SportNginAwsAuditor
       @tag_value
     end
 
-    def engine_helper
+    def engine_helper(engine)
       if engine.downcase.include? "post"
         return "PostgreSQL"
       elsif engine.downcase.include? "mysql"

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -32,10 +32,10 @@ module SportNginAwsAuditor
         print_data(slack, environment, data, "EC2Instance") if options[:ec2] || no_selection
 
         data = gather_data("RDSInstance", tag_name) if options[:rds] || no_selection
-        print_data(slack, environment, data, "RDSInstance") if options[:ec2] || no_selection
+        print_data(slack, environment, data, "RDSInstance") if options[:rds] || no_selection
 
         data = gather_data("CacheInstance", tag_name) if options[:cache] || no_selection
-        print_data(slack, environment, data, "CacheInstance") if options[:ec2] || no_selection
+        print_data(slack, environment, data, "CacheInstance") if options[:cache] || no_selection
       end
 
       def self.gather_data(class_type, tag_name)

--- a/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
@@ -118,7 +118,7 @@ module SportNginAwsAuditor
         allow(CacheInstance).to receive(:cache).and_return(cache_client)
         instances = CacheInstance::get_instances("tag_name")
         instance = instances.first
-        expect(instance.to_s).to eq("redis cache.t2.small")
+        expect(instance.to_s).to eq("Redis cache.t2.small")
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -56,7 +56,7 @@ module SportNginAwsAuditor
         expect(instance.id).to eq("our-service")
         expect(instance.multi_az).to eq("Single-AZ")
         expect(instance.instance_type).to eq("db.t2.small")
-        expect(instance.engine).to eq("mysql")
+        expect(instance.engine).to eq("MySQL")
       end
     end
 
@@ -97,7 +97,7 @@ module SportNginAwsAuditor
         expect(reserved_instance.id).to eq("555te4yy-1234-555c-5678-thisisafake!!")
         expect(reserved_instance.multi_az).to eq("Single-AZ")
         expect(reserved_instance.instance_type).to eq("db.t2.small")
-        expect(reserved_instance.engine).to eq("mysql")
+        expect(reserved_instance.engine).to eq("MySQL")
       end
     end
 


### PR DESCRIPTION
Description and Impact
----------------------
The logic for recognizing Windows/Linux/VPC instances was wrong previously. Now the logic should be fixed to more accurately represent the platform of each instance. Previously, all instances came out as saying VPC, but we want to also be specific about whether it is Windows or Linux, so now it will read out `Linux VPC` or `Windows VPC`.

Deploy Plan
-----------
* checkout master
* `op accept-pull`
* `soyuz deploy` and push new version to RubyGems

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `bin/sport-ngin-aws-auditor audit [account]` verify that it still works
  - [x] Verify that the number of Windows instances showing up matches our actual number of Windows instances
- [x] Verify that previous commands still continue to work as expected
  - [x] Run `bin/sport-ngin-aws-auditor inspect [account]`
  - [x] Run `bin/sport-ngin-aws-auditor audit --rds [account]` to verify that only RDS instances are audited
  - [x] Run `bin/sport-ngin-aws-auditor audit --reserved [account]` to see just a list of reserved instances
