### PR TITLE
Add other RDS engine types

### DIFF
--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -8,6 +8,23 @@ module SportNginAwsAuditor
 
     class << self
       attr_accessor :instances, :reserved_instances
+
+      def get_instances(tag_name=nil)
+        return @instances if @instances
+        account_id = get_account_id
+        @instances = cache.describe_cache_clusters.cache_clusters.map do |instance|
+          next unless instance.cache_cluster_status.to_s == 'available'
+          new(instance, account_id, tag_name, cache)
+        end.compact
+      end
+
+      def get_reserved_instances
+        return @reserved_instances if @reserved_instances
+        @reserved_instances = cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
+          next unless instance.state.to_s == 'active'
+          new(instance)
+        end.compact
+      end
     end
 
     attr_accessor :id, :name, :instance_type, :engine, :count, :tag_value
@@ -30,7 +47,7 @@ module SportNginAwsAuditor
           region = "us-east-1" if region == "Multiple"
           arn = "arn:aws:elasticache:#{region}:#{account_id}:cluster:#{self.id}"
 
-           # go through to see if the tag we're looking for is one of them
+          # go through to see if the tag we're looking for is one of them
           cache.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
@@ -44,26 +61,8 @@ module SportNginAwsAuditor
       "#{engine.capitalize} #{instance_type}"
     end
 
-    def self.get_instances(tag_name=nil)
-      return @instances if @instances
-      account_id = get_account_id
-      @instances = cache.describe_cache_clusters.cache_clusters.map do |instance|
-        next unless instance.cache_cluster_status.to_s == 'available'
-        new(instance, account_id, tag_name, cache)
-      end.compact
-    end
-
-    def self.get_reserved_instances
-      return @reserved_instances if @reserved_instances
-      @reserved_instances = cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
-        next unless instance.state.to_s == 'active'
-        new(instance)
-      end.compact
-    end
-
     def no_reserved_instance_tag_value
       @tag_value
     end
-    
   end
 end

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -28,7 +28,6 @@ module SportNginAwsAuditor
     end
 
     attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value
-
     def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -8,16 +8,34 @@ module SportNginAwsAuditor
 
     class << self
       attr_accessor :instances, :reserved_instances
+
+      def get_instances(tag_name=nil)
+        return @instances if @instances
+        account_id = get_account_id
+        @instances = rds.describe_db_instances.db_instances.map do |instance|
+          next unless instance.db_instance_status.to_s == 'available'
+          new(instance, account_id, tag_name, rds)
+        end.compact
+      end
+
+      def get_reserved_instances
+        return @reserved_instances if @reserved_instances
+        @reserved_instances = rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
+          next unless instance.state.to_s == 'active'
+          new(instance)
+        end.compact
+      end
     end
 
     attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value
+
     def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.product_description)
-        self.count = 1
+        self.count = rds_instance.db_instance_count
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
@@ -44,35 +62,41 @@ module SportNginAwsAuditor
       "#{engine} #{multi_az} #{instance_type}"
     end
 
-    def self.get_instances(tag_name=nil)
-      return @instances if @instances
-      account_id = get_account_id
-      @instances = rds.describe_db_instances.db_instances.map do |instance|
-        next unless instance.db_instance_status.to_s == 'available'
-        new(instance, account_id, tag_name, rds)
-      end.compact
-    end
-
-    def self.get_reserved_instances
-      return @reserved_instances if @reserved_instances
-      @reserved_instances = rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
-        next unless instance.state.to_s == 'active'
-        new(instance)
-      end.compact
-    end
-
     def no_reserved_instance_tag_value
-      @tag_value
+      tag_value
     end
 
+    # Generates a name based on the RDS engine or product description
     def engine_helper(engine)
-      if engine.downcase.include? "post"
-        return "PostgreSQL"
-      elsif engine.downcase.include? "mysql"
-        return "MySQL"
+      case engine
+      when 'aurora'
+        'Aurora'
+      when 'mariadb'
+        'MariaDB'
+      when 'mysql'
+        'MySQL'
+      when 'oracle-ee',     'oracle-ee(byol)'
+        'Oracle EE'
+      when 'oracle-se',     'oracle-se(byol)'
+        'Oracle SE'
+      when 'oracle-se1',    'oracle-se1(li)'
+        'Oracle SE One'
+      when 'oracle-se2',    'oracle-se2 (byol)' # extra space required
+        'Oracle SE Two'
+      when 'postgres',      'postgresql'
+        'PostgreSQL'
+      when 'sqlserver-ee',  'sqlserver-ee(li)'
+        'SQL Server EE'
+      when 'sqlserver-ex',  'sqlserver-ex(li)'
+        'SQL Server EX'
+      when 'sqlserver-se',  'sqlserver-se(byol)'
+        'SQL Server SE'
+      when 'sqlserver-web', 'sqlserver-web(li)'
+        'SQL Server Web'
+      else
+        'Unknown DB Engine'
       end
     end
     private :engine_helper
-
   end
 end

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -67,7 +67,7 @@ module SportNginAwsAuditor
 
     # Generates a name based on the RDS engine or product description
     def engine_helper(engine)
-      case engine
+      case engine.downcase
       when 'aurora'
         'Aurora'
       when 'mariadb'

--- a/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
@@ -39,19 +39,19 @@ module SportNginAwsAuditor
       end
 
       it "should make a cache_instance for each instance" do
-        instances = CacheInstance::get_instances("tag_name")
+        instances = CacheInstance.get_instances("tag_name")
         expect(instances.first).to be_an_instance_of(CacheInstance)
         expect(instances.last).to be_an_instance_of(CacheInstance)
       end
 
       it "should return an array of cache_instances" do
-        instances = CacheInstance::get_instances("tag_name")
+        instances = CacheInstance.get_instances("tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = CacheInstance::get_instances("tag_name")
+        instances = CacheInstance.get_instances("tag_name")
         instance = instances.first
         expect(instance.id).to eq("job-queue-cluster")
         expect(instance.name).to eq("job-queue-cluster")
@@ -80,19 +80,19 @@ module SportNginAwsAuditor
       end
 
       it "should make a reserved_cache_instance for each instance" do
-        reserved_instances = CacheInstance::get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances
         expect(reserved_instances.first).to be_an_instance_of(CacheInstance)
         expect(reserved_instances.last).to be_an_instance_of(CacheInstance)
       end
 
       it "should return an array of reserved_cache_instances" do
-        reserved_instances = CacheInstance::get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = CacheInstance::get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("job-queue-cluster")
         expect(reserved_instance.name).to eq("job-queue-cluster")
@@ -116,7 +116,7 @@ module SportNginAwsAuditor
         tags = double('tags', tag_list: [tag1, tag2])
         cache_client = double('cache_client', describe_cache_clusters: cache_clusters, list_tags_for_resource: tags)
         allow(CacheInstance).to receive(:cache).and_return(cache_client)
-        instances = CacheInstance::get_instances("tag_name")
+        instances = CacheInstance.get_instances("tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("Redis cache.t2.small")
       end

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -41,19 +41,19 @@ module SportNginAwsAuditor
       end
 
       it "should make an ec2_instance for each instance" do
-        instances = EC2Instance::get_instances("tag_name")
+        instances = EC2Instance.get_instances("tag_name")
         expect(instances.first).to be_an_instance_of(EC2Instance)
         expect(instances.last).to be_an_instance_of(EC2Instance)
       end
 
       it "should return an array of ec2_instances" do
-        instances = EC2Instance::get_instances("tag_name")
+        instances = EC2Instance.get_instances("tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = EC2Instance::get_instances("tag_name")
+        instances = EC2Instance.get_instances("tag_name")
         instance = instances.first
         expect(instance.stack_name).to eq("our_app_service_2")
         expect(instance.name).to eq("our-app-instance-100")
@@ -64,7 +64,7 @@ module SportNginAwsAuditor
       end
 
       it "should recognize Windows vs. Linux" do
-        instances = EC2Instance::get_instances("tag_name")
+        instances = EC2Instance.get_instances("tag_name")
         instance1 = instances.first
         instance2 = instances.last
         expect(instance1.platform).to eq("Linux VPC")
@@ -94,19 +94,19 @@ module SportNginAwsAuditor
       end
 
       it "should make a reserved_ec2_instance for each instance" do
-        reserved_instances = EC2Instance::get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances
         expect(reserved_instances.first).to be_an_instance_of(EC2Instance)
         expect(reserved_instances.last).to be_an_instance_of(EC2Instance)
       end
 
       it "should return an array of reserved_ec2_instances" do
-        reserved_instances = EC2Instance::get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = EC2Instance::get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("12345-dfas-1234-asdf-thisisfake!!")
         expect(reserved_instance.platform).to eq("Windows VPC")
@@ -116,7 +116,7 @@ module SportNginAwsAuditor
       end
 
       it "should recognize Windows vs. Linux" do
-        reserved_instances = EC2Instance::get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances
         reserved_instance1 = reserved_instances.first
         reserved_instance2 = reserved_instances.last
         expect(reserved_instance1.platform).to eq("Windows VPC")
@@ -146,7 +146,7 @@ module SportNginAwsAuditor
         tags = double('tags', tags: [name_tag, stack_tag])
         ec2_client = double('ec2_client', describe_instances: ec2_instances, describe_tags: tags)
         allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
-        instances = EC2Instance::get_instances("tag_name")
+        instances = EC2Instance.get_instances("tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("Linux VPC us-east-1d t2.large")
       end
@@ -180,20 +180,20 @@ module SportNginAwsAuditor
       end
 
       it "should return a hash where the first element's key is the opsworks:stack name of the instances" do
-        instances = EC2Instance::get_instances
-        buckets = EC2Instance::bucketize
+        instances = EC2Instance.get_instances
+        buckets = EC2Instance.bucketize
         expect(buckets.first.first).to eq("our_app_service_2")
       end
 
       it "should return a hash where the last element's key is the opsworks:stack name of the instances" do
-        instances = EC2Instance::get_instances
-        buckets = EC2Instance::bucketize
+        instances = EC2Instance.get_instances
+        buckets = EC2Instance.bucketize
         expect(buckets.last.first).to eq("our_app_service_2")
       end
 
       it "should return a hash where each element is a list of ec2_instances" do
-        instances = EC2Instance::get_instances
-        buckets = EC2Instance::bucketize
+        instances = EC2Instance.get_instances
+        buckets = EC2Instance.bucketize
         expect(buckets).not_to be_empty
         expect(buckets.length).to eq(1)
         expect(buckets.first.length).to eq(2)

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -39,19 +39,19 @@ module SportNginAwsAuditor
       end
 
       it "should make a rds_instance for each instance" do
-        instances = RDSInstance::get_instances("tag_name")
+        instances = RDSInstance.get_instances("tag_name")
         expect(instances.first).to be_an_instance_of(RDSInstance)
         expect(instances.last).to be_an_instance_of(RDSInstance)
       end
 
       it "should return an array of rds_instances" do
-        instances = RDSInstance::get_instances("tag_name")
+        instances = RDSInstance.get_instances("tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = RDSInstance::get_instances("tag_name")
+        instances = RDSInstance.get_instances("tag_name")
         instance = instances.first
         expect(instance.id).to eq("our-service")
         expect(instance.multi_az).to eq("Single-AZ")
@@ -66,13 +66,15 @@ module SportNginAwsAuditor
                                                                  multi_az: false,
                                                                  db_instance_class: "db.t2.small",
                                                                  state: "active",
-                                                                 product_description: "mysql",
+                                                                 product_description: "oracle-se2 (byol)",
+                                                                 db_instance_count: 1,
                                                                  class: "Aws::RDS::Types::ReservedDBInstance")
         reserved_rds_instance2 = double('reserved_rds_instance', reserved_db_instances_offering_id: "555te4yy-1234-555c-5678-thisisafake!!",
                                                                  multi_az: false,
                                                                  db_instance_class: "db.m3.large",
                                                                  state: "active",
                                                                  product_description: "postgresql",
+                                                                 db_instance_count: 2,
                                                                  class: "Aws::RDS::Types::ReservedDBInstance")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance1, reserved_rds_instance2])
         rds_client = double('rds_client', describe_reserved_db_instances: reserved_db_instances)
@@ -80,24 +82,24 @@ module SportNginAwsAuditor
       end
 
       it "should make a reserved_rds_instance for each instance" do
-        reserved_instances = RDSInstance::get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances
         expect(reserved_instances.first).to be_an_instance_of(RDSInstance)
         expect(reserved_instances.last).to be_an_instance_of(RDSInstance)
       end
 
       it "should return an array of reserved_rds_instances" do
-        reserved_instances = RDSInstance::get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = RDSInstance::get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("555te4yy-1234-555c-5678-thisisafake!!")
         expect(reserved_instance.multi_az).to eq("Single-AZ")
         expect(reserved_instance.instance_type).to eq("db.t2.small")
-        expect(reserved_instance.engine).to eq("MySQL")
+        expect(reserved_instance.engine).to eq("Oracle SE Two")
       end
     end
 
@@ -108,11 +110,12 @@ module SportNginAwsAuditor
                                                                 db_instance_class: "db.t2.small",
                                                                 state: "active",
                                                                 product_description: "mysql",
+                                                                db_instance_count: 3,
                                                                 class: "Aws::RDS::Types::ReservedDBInstance")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance])
         rds_client = double('rds_client', describe_reserved_db_instances: reserved_db_instances)
         allow(RDSInstance).to receive(:rds).and_return(rds_client)
-        reserved_instances = RDSInstance::get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances
         reserved_instance = reserved_instances.first
         expect(reserved_instance.to_s).to eq("MySQL Single-AZ db.t2.small")
       end
@@ -122,7 +125,7 @@ module SportNginAwsAuditor
                                               multi_az: false,
                                               db_instance_class: "db.t2.small",
                                               db_instance_status: "available",
-                                              engine: "postgresql",
+                                              engine: "postgres",
                                               availability_zone: "us-east-1a",
                                               class: "Aws::RDS::Types::DBInstance")
         db_instances = double('db_instances', db_instances: [rds_instance])
@@ -131,7 +134,7 @@ module SportNginAwsAuditor
         tags = double('tags', tag_list: [tag1, tag2])
         rds_client = double('rds_client', describe_db_instances: db_instances, list_tags_for_resource: tags)
         allow(RDSInstance).to receive(:rds).and_return(rds_client)
-        instances = RDSInstance::get_instances("tag_name")
+        instances = RDSInstance.get_instances("tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("PostgreSQL Single-AZ db.t2.small")
       end


### PR DESCRIPTION
Also fixes an issue where rds reservations containing more than 1 reserved db instance would only be counted as a single reserved instance.

I was able to find the listings of available product_descriptions using this:
```
marker = nil
reserved_db_product_descriptions = []
loop do
  resp = rds_client.describe_reserved_db_instances_offerings({marker: marker})
  marker = resp.marker
  reserved_db_product_descriptions += resp.reserved_db_instances_offerings.map(&:product_description)
  break if marker.nil?
end
reserved_db_product_descriptions.uniq
=> ["sqlserver-ee(li)", "sqlserver-se(li)", "oracle-se(byol)", "mariadb", "sqlserver-ee(byol)", "oracle-se1(li)", "oracle-se2 (byol)", "sqlserver-se(byol)", "aurora", "sqlserver-web(li)", "postgresql", "oracle-ee(byol)", "mysql", "oracle-se1(byol)", "sqlserver-ex(li)"]
```
and the engines using
```
marker = nil
db_engines = []
loop do
  resp = rds_client.describe_db_engine_versions({marker: marker})
  marker = resp.marker
  db_engines += resp.db_engine_versions.map(&:engine)
  break if marker.nil?
end
db_engines.uniq
=> ["mariadb", "mysql", "oracle-ee", "oracle-se", "oracle-se1", "oracle-se2", "aurora", "postgres", "sqlserver-ee", "sqlserver-ex", "sqlserver-se", "sqlserver-web"]
```