### PR TITLE
Fixing bug where Slack will print discrepancies if there are *only* tagged instances

### DIFF
--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -88,7 +88,9 @@ module SportNginAwsAuditor
           end
         end
 
-        if discrepancy_hash.empty?
+        true_discrepancies = discrepancy_hash.dup.select{ |key, value| !key.include?(" with tag")}
+
+        if true_discrepancies.empty?
           slack_job = NotifySlack.new("All #{class_type} instances for #{environment} are up to date.")
           slack_job.perform
         else


### PR DESCRIPTION
Description and Impact
----------------------
When printing to Slack, don't say there are discrepancies if there are only instances that have tags.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `bin/sport-ngin-aws-auditor audit --slack [account]` and anything that has tags should show up with the asterik
- [x] Run `bin/sport-ngin-aws-auditor audit [account]` and verify that the number of instances with tags are the same when they print in the terminal and in slack