### PR TITLE
Print reserved instances that have retired in past week

### DIFF
--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -6,7 +6,7 @@ module SportNginAwsAuditor
     extend EC2Wrapper
 
     class << self
-      attr_accessor :instances, :reserved_instances
+      attr_accessor :instances, :reserved_instances, :retired_reserved_instances
 
       def get_instances(tag_name=nil)
         return @instances if @instances
@@ -23,6 +23,14 @@ module SportNginAwsAuditor
         return @reserved_instances if @reserved_instances
         @reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |ri|
           next unless ri.state == 'active'
+          new(ri, nil, ri.instance_count)
+        end.compact
+      end
+
+      def get_retired_reserved_instances
+        return @retired_reserved_instances if @retired_reserved_instances
+        @retired_reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |ri|
+          next unless ri.state == 'retired'
           new(ri, nil, ri.instance_count)
         end.compact
       end
@@ -52,7 +60,7 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value
+    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value, :expiration_date
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id
@@ -62,6 +70,7 @@ module SportNginAwsAuditor
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil
+        self.expiration_date = ec2_instance.end if ec2_instance.state == 'retired'
       elsif ec2_instance.class.to_s == "Aws::EC2::Types::Instance"
         self.id = ec2_instance.instance_id
         self.name = nil

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -21,17 +21,17 @@ module SportNginAwsAuditor
 
       def get_reserved_instances
         return @reserved_instances if @reserved_instances
-        @reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |ri|
-          next unless ri.state == 'active'
-          new(ri, nil, ri.instance_count)
+        @reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |instance|
+          next unless instance.state == 'active'
+          new(instance, nil, instance.instance_count)
         end.compact
       end
 
       def get_retired_reserved_instances
         return @retired_reserved_instances if @retired_reserved_instances
-        @retired_reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |ri|
-          next unless ri.state == 'retired'
-          new(ri, nil, ri.instance_count)
+        @retired_reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |instance|
+          next unless instance.state == 'retired'
+          new(instance, nil, instance.instance_count)
         end.compact
       end
 

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -28,17 +28,20 @@ module SportNginAwsAuditor
     end
 
     def compare(tag_name)
+      puts "comparing"
       differences = Hash.new()
       instances = get_instances(tag_name)
       instances_with_tag = filter_instances_with_tags(instances)
       instances_without_tag = filter_instance_without_tags(instances)
       instance_hash = instance_count_hash(instances_without_tag)
       ris = instance_count_hash(get_reserved_instances)
+      
       instance_hash.keys.concat(ris.keys).uniq.each do |key|
         instance_count = instance_hash.has_key?(key) ? instance_hash[key] : 0
         ris_count = ris.has_key?(key) ? ris[key] : 0
         differences[key] = ris_count - instance_count
       end
+      
       add_instances_with_tag_to_hash(instances_with_tag, differences)
       differences
     end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -28,7 +28,6 @@ module SportNginAwsAuditor
     end
 
     def compare(tag_name)
-      puts "comparing"
       differences = Hash.new()
       instances = get_instances(tag_name)
       instances_with_tag = filter_instances_with_tags(instances)
@@ -44,6 +43,12 @@ module SportNginAwsAuditor
       
       add_instances_with_tag_to_hash(instances_with_tag, differences)
       differences
+    end
+
+    def get_recent_retired_reserved_instances
+      get_retired_reserved_instances.select do |ri|
+        ri.expiration_date > (Time.now - 604800)
+      end
     end
 
     # assuming the value of the tag is in the form: 01/01/2000 like a date

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -45,6 +45,8 @@ module SportNginAwsAuditor
       differences
     end
 
+    # this gets all retired reserved instances and filters out only the ones that have expired
+    # within the past week
     def get_recent_retired_reserved_instances
       get_retired_reserved_instances.select do |ri|
         ri.expiration_date > (Time.now - 604800)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -57,16 +57,12 @@ module SportNginAwsAuditor
           retired_reserved_instances = klass.get_recent_retired_reserved_instances
         end
 
-        return_array = []
         compared_array = []
-
         instance_hash.each do |key, value|
           compared_array.push(Instance.new(key, value))
         end
 
-        return_array.push(compared_array)
-        return_array.push(retired_reserved_instances) if retired_reserved_instances
-        return_array
+        [compared_array, retired_reserved_instances]
       end
 
       def self.print_data(slack, environment, data, retired_reserved_instances, class_type)
@@ -81,7 +77,7 @@ module SportNginAwsAuditor
           puts header(class_type)
           data.each{ |instance| colorize(instance) }
           unless retired_reserved_instances.empty?
-            say "The following reserved #{class_type} have recently expired in #{environment}:"
+            say "The following reserved #{class_type}Instance have recently expired in #{environment}:"
             retired_reserved_instances.each { |ri| say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}"}
           end
         end

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -125,6 +125,7 @@ module SportNginAwsAuditor
 
       context "for retired_reserved_ec2_instances" do
         before :each do
+          @time = Time.now
           retired_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                            instance_type: "t2.medium",
                                                                            product_description: "Windows (Amazon VPC)",
@@ -132,7 +133,7 @@ module SportNginAwsAuditor
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 4,
                                                                            class: "Aws::EC2::Types::ReservedInstances",
-                                                                           end: "03-24-2991 93:19:3921 UTC")
+                                                                           end: @time - 86400)
           retired_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                            instance_type: "t2.small",
                                                                            product_description: "Linux/UNIX (Amazon VPC)",
@@ -140,7 +141,7 @@ module SportNginAwsAuditor
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 2,
                                                                            class: "Aws::EC2::Types::ReservedInstances",
-                                                                           end: "03-24-2991 93:19:3921 UTC")
+                                                                           end: @time - 86400)
           reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                    instance_type: "t2.small",
                                                                    product_description: "Linux/UNIX (Amazon VPC)",
@@ -161,7 +162,7 @@ module SportNginAwsAuditor
           expect(retired_reserved_instances.last).to be_an_instance_of(EC2Instance)
         end
 
-        it "should return an array of reserved_ec2_instances" do
+        it "should return an array of retired_reserved_ec2_instances" do
           retired_reserved_instances = EC2Instance.get_retired_reserved_instances
           expect(retired_reserved_instances).not_to be_empty
           expect(retired_reserved_instances.length).to eq(2)
@@ -175,6 +176,7 @@ module SportNginAwsAuditor
           expect(retired_reserved_instance.availability_zone).to eq("us-east-1b")
           expect(retired_reserved_instance.instance_type).to eq("t2.medium")
           expect(retired_reserved_instance.count).to eq(4)
+          expect(retired_reserved_instance.expiration_date).to be >= @time - 86500
         end
 
         it "should recognize Windows vs. Linux" do


### PR DESCRIPTION
Description and Impact
----------------------
Print the expiration date of recently retired reserved instances to help users complete their audits.

Deploy Plan
-----------
* checkout master
* `op accept-pull 16`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html

QA Plan
-------
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` from this branch of the repo and watch it also print the recently (within 1 week) retired reserved instances
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]` from this branch of the repo and watch this also work when printing to slack channel