### PR TITLE
Print retired tags into slack/terminal on audit

### DIFF
--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -1,0 +1,67 @@
+require_relative './instance_helper'
+
+module SportNginAwsAuditor
+  class AuditData
+
+    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name
+    def initialize(instances, reserved, class_type, tag_name)
+      if instances
+        self.selected_audit_type = "instances"
+      elsif reserved
+        self.selected_audit_type = "reserved"
+      else
+        self.selected_audit_type = "all"
+      end
+
+      self.klass = SportNginAwsAuditor.const_get(class_type)
+      self.tag_name = tag_name
+    end
+
+    def instances?
+      self.selected_audit_type == "instances"
+    end
+
+    def reserved?
+      self.selected_audit_type == "reserved"
+    end
+
+    def gather_data
+      if instances?
+        instance_hash, retired_tags = gather_instances_data
+      elsif reserved?
+        instance_hash = self.klass.instance_count_hash(self.klass.get_reserved_instances)
+      else
+        instance_hash, retired_tags, retired_ris = gather_all_data
+      end
+
+      compared_array = []
+      instance_hash.each do |key, value|
+        compared_array.push(Instance.new(key, value))
+      end
+
+      self.data = compared_array
+      self.retired_ris = retired_ris || nil
+      self.retired_tags = retired_tags || nil
+    end
+
+    def gather_instances_data
+      instances = self.klass.get_instances(tag_name)
+      retired_tags = self.klass.get_retired_tags(instances)
+      instances_with_tag = self.klass.filter_instances_with_tags(instances)
+      instances_without_tag = self.klass.filter_instance_without_tags(instances)
+      instance_hash = self.klass.instance_count_hash(instances_without_tag)
+      self.klass.add_instances_with_tag_to_hash(instances_with_tag, instance_hash)
+
+      return instance_hash, retired_tags
+    end
+
+    def gather_all_data
+      instances = self.klass.get_instances(tag_name)
+      retired_tags = self.klass.get_retired_tags(instances)
+      instance_hash = self.klass.compare(instances)
+      retired_ris = self.klass.get_recent_retired_reserved_instances
+
+      return instance_hash, retired_tags, retired_ris
+    end
+  end
+end

--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -5,14 +5,7 @@ module SportNginAwsAuditor
 
     attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name
     def initialize(instances, reserved, class_type, tag_name)
-      if instances
-        self.selected_audit_type = "instances"
-      elsif reserved
-        self.selected_audit_type = "reserved"
-      else
-        self.selected_audit_type = "all"
-      end
-
+      self.selected_audit_type = (!instances && !reserved) ? "all" : (instances ? "instances" : "reserved")
       self.klass = SportNginAwsAuditor.const_get(class_type)
       self.tag_name = tag_name
     end
@@ -25,12 +18,16 @@ module SportNginAwsAuditor
       self.selected_audit_type == "reserved"
     end
 
+    def all?
+      self.selected_audit_type == "all"
+    end
+
     def gather_data
       if instances?
         instance_hash, retired_tags = gather_instances_data
       elsif reserved?
         instance_hash = self.klass.instance_count_hash(self.klass.get_reserved_instances)
-      else
+      elsif all?
         instance_hash, retired_tags, retired_ris = gather_all_data
       end
 
@@ -40,8 +37,8 @@ module SportNginAwsAuditor
       end
 
       self.data = compared_array
-      self.retired_ris = retired_ris || nil
-      self.retired_tags = retired_tags || nil
+      self.retired_ris = retired_ris
+      self.retired_tags = retired_tags
     end
 
     def gather_instances_data

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -1,3 +1,6 @@
+require_relative './recently_retired_tag'
+require_relative './audit_data'
+
 module SportNginAwsAuditor
 	module InstanceHelper
 
@@ -27,10 +30,8 @@ module SportNginAwsAuditor
       instance_hash
     end
 
-    def compare(tag_name)
+    def compare(instances)
       differences = Hash.new()
-      instances = get_instances(tag_name)
-      retired_tags_hash = get_retired_tags(instances)
       instances_with_tag = filter_instances_with_tags(instances)
       instances_without_tag = filter_instance_without_tags(instances)
       instance_hash = instance_count_hash(instances_without_tag)
@@ -43,7 +44,7 @@ module SportNginAwsAuditor
       end
       
       add_instances_with_tag_to_hash(instances_with_tag, differences)
-      return differences, retired_tags_hash
+      differences
     end
 
     # this gets all retired reserved instances and filters out only the ones that have expired
@@ -72,15 +73,17 @@ module SportNginAwsAuditor
 
     # this returns a hash of all instances that have retired between 1 week ago and today
     def get_retired_tags(instances)
-      return_hash = {}
+      return_array = []
       
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
-        one_week_ago = (Date.today - 7).to_s
-        return_hash[instance.to_s] = value.to_s if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
+        one_week_ago = (Date.today - 10).to_s
+        if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
+          return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s)
+        end
       end
       
-      return_hash
+      return_array
     end
 
     def gather_instance_tag_date(instance)

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -77,7 +77,7 @@ module SportNginAwsAuditor
       
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
-        one_week_ago = (Date.today - 10).to_s
+        one_week_ago = (Date.today - 7).to_s
         if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
           return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s)
         end

--- a/lib/sport_ngin_aws_auditor/recently_retired_tag.rb
+++ b/lib/sport_ngin_aws_auditor/recently_retired_tag.rb
@@ -1,0 +1,12 @@
+require_relative './instance_helper'
+
+module SportNginAwsAuditor
+  class RecentlyRetiredTag
+
+    attr_accessor :value, :instance_name
+    def initialize(tag_value, instance_name)
+      self.value = tag_value
+      self.instance_name = instance_name
+    end
+  end
+end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -35,9 +35,10 @@ module SportNginAwsAuditor
 
         cycle.each do |c|
           all_data = gather_data(c.first, tag_name) if (c.last || no_selection)
-          data = all_data.first unless all_data.nil?
-          retired_reserved_instances = all_data.last if (all_data.length == 2 && !all_data.nil?)
-          print_data(slack, environment, data, retired_reserved_instances, c.first) if (c.last || no_selection)
+          data = all_data[0] unless all_data.nil?
+          retired_tags = all_data[1] if (all_data.length >= 2 && !all_data.nil?)
+          retired_ris = all_data[2] if (all_data.length >= 3 && !all_data.nil?)
+          print_data(slack, environment, data, retired_ris, retired_tags, c.first) if (c.last || no_selection)
         end
       end
 
@@ -46,6 +47,7 @@ module SportNginAwsAuditor
 
         if options[:instances]
           instances = klass.get_instances(tag_name)
+          retired_tags = klass.get_retired_tags(instances)
           instances_with_tag = klass.filter_instances_with_tags(instances)
           instances_without_tag = klass.filter_instance_without_tags(instances)
           instance_hash = klass.instance_count_hash(instances_without_tag)
@@ -53,8 +55,8 @@ module SportNginAwsAuditor
         elsif options[:reserved]
           instance_hash = klass.instance_count_hash(klass.get_reserved_instances)
         else
-          instance_hash = klass.compare(tag_name)
-          retired_reserved_instances = klass.get_recent_retired_reserved_instances
+          instance_hash, retired_tags = klass.compare(tag_name)
+          retired_ris = klass.get_recent_retired_reserved_instances
         end
 
         compared_array = []
@@ -62,25 +64,34 @@ module SportNginAwsAuditor
           compared_array.push(Instance.new(key, value))
         end
 
-        [compared_array, retired_reserved_instances]
+        [compared_array, retired_tags, retired_ris]
       end
 
-      def self.print_data(slack, environment, data, retired_reserved_instances, class_type)
+      def self.print_data(slack, environment, data, retired_ris, retired_tags, class_type)
         data.sort_by! { |instance| [instance.type, instance.name] }
 
         if slack
-          print_to_slack(data, retired_reserved_instances, class_type, environment)
+          print_to_slack(data, retired_ris, retired_tags, class_type, environment)
         elsif options[:reserved] || options[:instances]
           puts header(class_type)
           data.each{ |instance| say "<%= color('#{instance.name}: #{instance.count}', :white) %>" }
         else
           puts header(class_type)
           data.each{ |instance| colorize(instance) }
-          unless retired_reserved_instances.empty?
-            say "The following reserved #{class_type}Instance have recently expired in #{environment}:"
-            retired_reserved_instances.each { |ri| say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}"}
-          end
+
+          say_retired_ris(retired_ris, class_type, environment) unless retired_ris.empty?
+          say_retired_tags(retired_tags, class_type, environment) unless retired_tags.empty?
         end
+      end
+
+      def self.say_retired_ris(retired_ris, class_type, environment)
+        say "The following reserved #{class_type}Instances have recently expired in #{environment}:"
+        retired_ris.each { |ri| say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}" }
+      end
+
+      def self.say_retired_tags(retired_tags, class_type, environment)
+        say "The following #{class_type}Instance tags have recently expired in #{environment}:"
+        retired_tags.each { |name, value| say "#{name} on #{value}" }
       end
 
       def self.colorize(instance)
@@ -90,7 +101,7 @@ module SportNginAwsAuditor
         say "<%= color('#{name}: #{count}', :#{color}) %>"
       end
 
-      def self.print_to_slack(instances_array, retired_instances_array, class_type, environment)
+      def self.print_to_slack(instances_array, retired_ris, retired_tags, class_type, environment)
         discrepancy_array = []
 
         instances_array.each do |instance|
@@ -102,11 +113,11 @@ module SportNginAwsAuditor
         true_discrepancies = discrepancy_array.reject{ |instance| instance.tagged? }
 
         unless true_discrepancies.empty?
-          print_discrepancies(discrepancy_array, retired_instances_array, class_type, environment)
+          print_discrepancies(discrepancy_array, retired_ris, retired_tags, class_type, environment)
         end
       end
 
-      def self.print_discrepancies(discrepancy_array, retired_instances_array, class_type, environment)
+      def self.print_discrepancies(discrepancy_array, retired_ris, retired_tags, class_type, environment)
         title = "Some #{class_type} discrepancies for #{environment} exist:\n"
         slack_instances = NotifySlack.new(title)
 
@@ -119,19 +130,33 @@ module SportNginAwsAuditor
 
         slack_instances.perform
 
-        unless retired_instances_array.empty?
-          message = "The following reserved #{class_type} have recently expired in #{environment}:\n"
+        print_retired_ris(retired_ris, class_type, environment) unless retired_ris.empty?
+        print_retired_tags(retired_tags, class_type, environment) unless retired_tags.empty?
+      end
 
-          retired_instances_array.each do |ri|
-            name = ri.to_s
-            count = ri.count
-            expiration_date = ri.expiration_date
-            message << "*#{name}* (#{count}) on *#{expiration_date}*\n"
-          end
-          
-          slack_retired_instances = NotifySlack.new(message)
-          slack_retired_instances.perform
+      def self.print_retired_ris(retired_ris, class_type, environment)
+        message = "The following reserved #{class_type}s have recently expired in #{environment}:\n"
+
+        retired_ris.each do |ri|
+          name = ri.to_s
+          count = ri.count
+          expiration_date = ri.expiration_date
+          message << "*#{name}* (#{count}) on *#{expiration_date}*\n"
         end
+          
+        slack_retired_ris = NotifySlack.new(message)
+        slack_retired_ris.perform
+      end
+
+      def self.print_retired_tags(retired_tags, class_type, environment)
+        message = "The following #{class_type} tags have recently expired in #{environment}:\n"
+
+        retired_tags.each do |name, value|
+          message << "*#{name}* on *#{value}*\n"
+        end
+
+        slack_retired_tags = NotifySlack.new(message)
+        slack_retired_tags.perform
       end
 
       def self.color_chooser(instance)

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -1,0 +1,141 @@
+require "sport_ngin_aws_auditor"
+
+module SportNginAwsAuditor
+  describe AuditData do
+    before :each do
+      @instance = double('instance')
+      @instance1 = double('ec2_instance1')
+      @instance2 = double('ec2_instance2')
+      @instance3 = double('ec2_instance3')
+      @instance4 = double('ec2_instance4')
+      @ec2_instances = [@instance1, @instance2]
+      @retired_ris = [@instance3, @instance4]
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_instances).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_with_tags).and_return([])
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instance_without_tags).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:instance_count_hash).and_return({'instance1' => 1,
+                                                                                           'instance2' => 1})
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:add_instances_with_tag_to_hash).and_return({'instance1' => 1,
+                                                                                                      'instance2' => 1})
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:compare).and_return({'instance1' => 1,
+                                                                               'instance2' => 1})
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_recent_retired_reserved_instances).and_return(@retired_ris)
+      allow(Instance).to receive(:new).and_return(@instance)
+    end
+
+    context '#initialization' do
+      it 'should gather instance data' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.selected_audit_type).to eq("instances")
+      end
+
+      it 'should gather reserved instance data' do
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.selected_audit_type).to eq("reserved")
+      end
+
+      it 'should by default gather instance data' do
+        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.selected_audit_type).to eq("instances")
+      end
+
+      it 'should gather all data to compare' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.selected_audit_type).to eq("all")
+      end
+
+      it 'should use EC2Instance class' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.klass).to eq(SportNginAwsAuditor::EC2Instance)
+      end
+
+      it 'should use EC2Instance class' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.tag_name).to eq("no-reserved-instance")
+      end
+    end
+
+    context '#instances?' do
+      it 'should return true' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.instances?).to eq(true)
+      end
+
+      it 'should return true' do
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.instances?).to eq(false)
+      end
+    end
+
+    context '#reserved?' do
+      it 'should return true' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.reserved?).to eq(false)
+      end
+
+      it 'should return true' do
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.reserved?).to eq(true)
+      end
+    end
+
+    context '#all?' do
+      it 'should return true' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.all?).to eq(false)
+      end
+
+      it 'should return true' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        expect(audit_results.all?).to eq(true)
+      end
+    end
+
+    context '#gather_data' do
+      it 'should gather some empty results by comparison' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results.gather_data
+        expect(audit_results.data).to eq([@instance, @instance])
+        expect(audit_results.retired_tags).to eq([])
+        expect(audit_results.retired_ris).to eq(@retired_ris)
+      end
+
+      it 'should gather some empty results from just instances' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results.gather_data
+        expect(audit_results.data).to eq([@instance, @instance])
+        expect(audit_results.retired_tags).to eq([])
+        expect(audit_results.retired_ris).to eq(nil)
+      end
+
+      it 'should gather some empty results from just reserved' do
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        audit_results.gather_data
+        expect(audit_results.data).to eq([@instance, @instance])
+        expect(audit_results.retired_tags).to eq(nil)
+        expect(audit_results.retired_ris).to eq(nil)
+      end
+    end
+
+    context '#gather_instances_data' do
+      it 'should gather some instances data but not convert' do
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        result1, result2 = audit_results.gather_instances_data
+        expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
+        expect(result2).to eq([])
+      end
+    end
+
+    context '#gather_all_data' do
+      it 'should gather some comparison data but not convert' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        result1, result2, result3 = audit_results.gather_all_data
+        expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
+        expect(result2).to eq([])
+        expect(result3).to eq(@retired_ris)
+      end
+    end
+  end
+end

--- a/spec/sport_ngin_aws_auditor/recently_retired_tag_spec.rb
+++ b/spec/sport_ngin_aws_auditor/recently_retired_tag_spec.rb
@@ -1,0 +1,15 @@
+require "sport_ngin_aws_auditor"
+
+module SportNginAwsAuditor
+  describe RecentlyRetiredTag do
+    it 'should have an instance name as an instance_name' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small')
+      expect(tag.instance_name).to eq('Linux VPC us-east-1b t2.small')
+    end
+
+    it 'should have a string date as a value' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small')
+      expect(tag.value).to eq('09/01/2000')
+    end
+  end
+end


### PR DESCRIPTION
Description and Impact
----------------------
Print the tags of instances that have expired between the past week and today.

Deploy Plan
-----------
* checkout master
* `op accept-pull 17`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

QA Plan
-------
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` from this branch of the repo and watch it also print the recently (within 1 week) retired reserved instances
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]` from this branch of the repo and watch this also work when printing to slack channel