### PR TITLE
Clarifying printout of audit command

### DIFF
--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -35,7 +35,7 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :instance_type, :engine, :count, :tag_value, :expiration_date
+    attr_accessor :id, :name, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(cache_instance, account_id=nil, tag_name=nil, cache=nil)
       if cache_instance.class.to_s == "Aws::ElastiCache::Types::ReservedCacheNode"
         self.id = cache_instance.reserved_cache_node_id
@@ -60,6 +60,8 @@ module SportNginAwsAuditor
           cache.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
+            elsif tag.key == 'no-reserved-instance-reason'
+              self.tag_reason = tag.value
             end
           end
         end

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value, :expiration_date
+    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id
@@ -73,7 +73,7 @@ module SportNginAwsAuditor
         self.expiration_date = ec2_instance.end if ec2_instance.state == 'retired'
       elsif ec2_instance.class.to_s == "Aws::EC2::Types::Instance"
         self.id = ec2_instance.instance_id
-        self.name = nil
+        self.name = ec2_instance.key_name
         self.platform = platform_helper((ec2_instance.platform || ''), ec2_instance.vpc_id)
         self.availability_zone = ec2_instance.placement.availability_zone
         self.instance_type = ec2_instance.instance_type
@@ -85,6 +85,8 @@ module SportNginAwsAuditor
           ec2_instance.tags.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
+            elsif tag.key == 'no-reserved-instance-reason'
+              self.tag_reason = tag.value
             end
           end
         end

--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -4,41 +4,45 @@ module SportNginAwsAuditor
   class Instance
     extend InstanceHelper
 
-    attr_accessor :name, :count, :type
-    def initialize(name, count)
-      if name.include?(" with tag")
-        name = name.dup # because name is a frozen string right now
-        name.slice!(" with tag")
-        self.name = name
-        self.type = "tagged"
+    attr_accessor :type, :count, :category, :tag_value, :reason, :name
+    def initialize(type, data_array)
+      if type.include?(" with tag")
+        type = type.dup # because type is a frozen string right now
+        type.slice!(" with tag")
+        self.type = type
+        self.category = "tagged"
+        self.name = data_array[1] || nil
+        self.reason = data_array[2] || nil
+        self.tag_value = data_array[3] || nil
       else
-        self.name = name
-        if count < 0
-          self.type = "running"
-        elsif count == 0
-          self.type = "matched"
-        elsif count > 0 
-          self.type = "reserved"
+        self.type = type
+
+        if data_array[0] < 0
+          self.category = "running"
+        elsif data_array[0] == 0
+          self.category = "matched"
+        elsif data_array[0] > 0
+          self.category = "reserved"
         end
       end
 
-      self.count = count.abs
+      self.count = data_array[0].abs
     end
 
     def tagged?
-      self.type == "tagged"
+      self.category == "tagged"
     end
 
     def reserved?
-      self.type == "reserved"
+      self.category == "reserved"
     end
 
     def running?
-      self.type == "running"
+      self.category == "running"
     end
 
     def matched?
-      self.type == "matched"
+      self.category == "matched"
     end
   end
 end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -90,7 +90,7 @@ module SportNginAwsAuditor
       
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
-        one_week_ago = (Date.today - 15).to_s
+        one_week_ago = (Date.today - 7).to_s
         if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
           return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name)
         end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -16,8 +16,12 @@ module SportNginAwsAuditor
       instance_hash = Hash.new()
       instances.each do |instance|
         next if instance.nil?
-        instance_hash[instance.to_s] = instance_hash.has_key?(instance.to_s) ? instance_hash[instance.to_s] + instance.count : instance.count
+        instance_hash[instance.to_s] = instance_hash.has_key?(instance.to_s) ? instance_hash[instance.to_s][0] + instance.count : instance.count
       end if instances
+
+      instance_hash.each do |key, value|
+        instance_hash[key] = [instance_hash[key]]
+      end
       instance_hash
     end
 
@@ -25,7 +29,16 @@ module SportNginAwsAuditor
       instances_to_add.each do |instance|
         next if instance.nil?
         key = instance.to_s << " with tag"
-        instance_hash[key] = instance_hash.has_key?(key) ? instance_hash[key] + 1 : 1
+        instance_result = []
+        if instance_hash.has_key?(key)
+          instance_result << instance_hash[key][0] + 1
+        else
+          instance_result << 1
+        end
+        instance_result << instance.name
+        instance_result << instance.tag_reason
+        instance_result << instance.tag_value
+        instance_hash[key] = instance_result
       end if instances_to_add
       instance_hash
     end
@@ -38,9 +51,9 @@ module SportNginAwsAuditor
       ris = instance_count_hash(get_reserved_instances)
       
       instance_hash.keys.concat(ris.keys).uniq.each do |key|
-        instance_count = instance_hash.has_key?(key) ? instance_hash[key] : 0
-        ris_count = ris.has_key?(key) ? ris[key] : 0
-        differences[key] = ris_count - instance_count
+        instance_count = instance_hash.has_key?(key) ? instance_hash[key][0] : 0
+        ris_count = ris.has_key?(key) ? ris[key][0] : 0
+        differences[key] = [ris_count - instance_count]
       end
       
       add_instances_with_tag_to_hash(instances_with_tag, differences)
@@ -77,9 +90,9 @@ module SportNginAwsAuditor
       
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
-        one_week_ago = (Date.today - 7).to_s
+        one_week_ago = (Date.today - 15).to_s
         if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
-          return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s)
+          return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name)
         end
       end
       

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -92,7 +92,7 @@ module SportNginAwsAuditor
         value = gather_instance_tag_date(instance)
         one_week_ago = (Date.today - 7).to_s
         if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
-          return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name)
+          return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name, instance.tag_reason)
         end
       end
       

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -35,7 +35,7 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value, :expiration_date
+    attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
@@ -46,6 +46,7 @@ module SportNginAwsAuditor
         self.expiration_date = rds_instance.start_time + rds_instance.duration if rds_instance.state == 'retired'
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
+        self.name = rds_instance.db_name
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.engine)
@@ -60,6 +61,8 @@ module SportNginAwsAuditor
           rds.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
+            elsif tag.key == 'no-reserved-instance-reason'
+              self.tag_reason = tag.value
             end
           end
         end

--- a/lib/sport_ngin_aws_auditor/recently_retired_tag.rb
+++ b/lib/sport_ngin_aws_auditor/recently_retired_tag.rb
@@ -3,10 +3,12 @@ require_relative './instance_helper'
 module SportNginAwsAuditor
   class RecentlyRetiredTag
 
-    attr_accessor :value, :instance_name
-    def initialize(tag_value, instance_name)
+    attr_accessor :value, :instance_type, :instance_name, :reason
+    def initialize(tag_value, instance_type, instance_name, reason=nil)
       self.value = tag_value
+      self.instance_type = instance_type
       self.instance_name = instance_name
+      self.reason = reason
     end
   end
 end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -71,7 +71,7 @@ module SportNginAwsAuditor
         say "The following #{class_type}Instance tags have recently expired in #{environment}:"
         retired_tags.each do |tag|
           if tag.reason
-            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because of #{reason}"
+            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because of #{tag.reason}"
           else
             say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value}"
           end
@@ -98,19 +98,19 @@ module SportNginAwsAuditor
         tagged_array = []
 
         audit_results.data.each do |instance|
-          unless instance.matched?
+          unless instance.matched? || instance.tagged?
             discrepancy_array.push(instance)
           end
+        end
+
+        unless discrepancy_array.empty?
+          print_discrepancies(discrepancy_array, audit_results, class_type, environment)
         end
 
         audit_results.data.each do |instance|
           if instance.tagged?
             tagged_array.push(instance)
           end
-        end
-
-        unless discrepancy_array.empty?
-          print_discrepancies(discrepancy_array, audit_results, class_type, environment)
         end
 
         unless tagged_array.empty?
@@ -182,7 +182,7 @@ module SportNginAwsAuditor
 
         retired_tags.each do |tag|
           if tag.reason
-            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}* because of #{reason}\n"
+            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}* because of #{tag.reason}\n"
           else
             message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}*\n"
           end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -42,13 +42,13 @@ module SportNginAwsAuditor
       end
 
       def self.print_data(slack, audit_results, class_type, environment)
-        audit_results.data.sort_by! { |instance| [instance.type, instance.name] }
+        audit_results.data.sort_by! { |instance| [instance.category, instance.type] }
 
         if slack
           print_to_slack(audit_results, class_type, environment)
         elsif options[:reserved] || options[:instances]
           puts header(class_type)
-          audit_results.data.each{ |instance| say "<%= color('#{instance.name}: #{instance.count}', :white) %>" }
+          audit_results.data.each{ |instance| say "<%= color('#{instance.type}: #{instance.count}', :white) %>" }
         else
           retired_ris = audit_results.retired_ris
           retired_tags = audit_results.retired_tags
@@ -68,14 +68,28 @@ module SportNginAwsAuditor
 
       def self.say_retired_tags(retired_tags, class_type, environment)
         say "The following #{class_type}Instance tags have recently expired in #{environment}:"
-        retired_tags.each { |tag| say "#{tag.instance_name} on #{tag.value}" }
+        retired_tags.each do |tag|
+          if tag.reason
+            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because of #{reason}"
+          else
+            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value}"
+          end
+        end
       end
 
       def self.colorize(instance)
-        name = instance.name
+        name = instance.type
         count = instance.count
-        color, rgb = color_chooser(instance)
-        say "<%= color('#{name}: #{count}', :#{color}) %>"
+        color, rgb, prefix = color_chooser(instance)
+        if instance.tagged?
+          if instance.reason
+            say "<%= color('#{prefix} #{name}: #{count} (expiring on #{instance.tag_value} because of #{instance.reason})', :#{color}) %>"
+          else
+            say "<%= color('#{prefix} #{name}: #{count} (expiring on #{instance.tag_value})', :#{color}) %>"
+          end
+        else
+          say "<%= color('#{prefix} #{name}: #{count}', :#{color}) %>"
+        end
       end
 
       def self.print_to_slack(audit_results, class_type, environment)
@@ -99,10 +113,22 @@ module SportNginAwsAuditor
         slack_instances = NotifySlack.new(title)
 
         discrepancy_array.each do |discrepancy|
-          name = discrepancy.name
+          name = discrepancy.type
           count = discrepancy.count
-          color, rgb = color_chooser(discrepancy)
-          slack_instances.attachments.push({"color" => rgb, "text" => "#{name}: #{count}", "mrkdwn_in" => ["text"]})
+          color, rgb, prefix = color_chooser(discrepancy)
+          text = "#{prefix} #{name}: #{count}"
+
+          if discrepancy.tagged?
+            if discrepancy.reason
+              text = "#{prefix} #{name}: #{count} (expiring on #{discrepancy.tag_value} because of #{discrepancy.reason})"
+            else
+              text = "#{prefix} #{name}: #{count} (expiring on #{discrepancy.tag_value})"
+            end
+          else
+            text = "#{prefix} #{name}: #{count}"
+          end
+
+          slack_instances.attachments.push({"color" => rgb, "text" => text, "mrkdwn_in" => ["text"]})
         end
 
         slack_instances.perform
@@ -132,7 +158,11 @@ module SportNginAwsAuditor
         message = "The following #{class_type} tags have recently expired in #{environment}:\n"
 
         retired_tags.each do |tag|
-          message << "*#{tag.instance_name}* on *#{tag.value}*\n"
+          if tag.reason
+            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}* because of #{reason}\n"
+          else
+            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}*\n"
+          end
         end
 
         slack_retired_tags = NotifySlack.new(message)
@@ -141,13 +171,13 @@ module SportNginAwsAuditor
 
       def self.color_chooser(instance)
         if instance.tagged?
-          return "blue", "#0000CC"
+          return "blue", "#0000CC", "TAGGED -"
         elsif instance.running?
-          return "yellow", "#FFD700"
+          return "yellow", "#FFD700", "MISSING RI -"
         elsif instance.matched?
-          return "green", "#32CD32"
+          return "green", "#32CD32", "MATCHED RI -"
         elsif instance.reserved?
-          return "red", "#BF1616"
+          return "red", "#BF1616", "UNUSED RI -"
         end
       end
 

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -22,7 +22,8 @@ module SportNginAwsAuditor
                                                state: state,
                                                placement: placement,
                                                tags: instance_tags,
-                                               class: "Aws::EC2::Types::Instance")
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-01')
         ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
                                                instance_type: "t2.large",
                                                vpc_id: "vpc-alsofake",
@@ -30,7 +31,8 @@ module SportNginAwsAuditor
                                                state: state,
                                                placement: placement,
                                                tags: instance_tags,
-                                               class: "Aws::EC2::Types::Instance")
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-02')
         ec2_reservations = double('ec2_reservations', instances: [ec2_instance1, ec2_instance2])
         ec2_instances = double('ec2_instances', reservations: [ec2_reservations])
         name_tag = { key: "Name", value: "our-app-instance-100" }
@@ -203,7 +205,8 @@ module SportNginAwsAuditor
                                               state: state,
                                               placement: placement,
                                               tags: instance_tags,
-                                              class: "Aws::EC2::Types::Instance")
+                                              class: "Aws::EC2::Types::Instance",
+                                              key_name: 'Example-instance-01')
         ec2_reservations = double('ec2_reservations', instances: [ec2_instance])
         ec2_instances = double('ec2_instances', reservations: [ec2_reservations])
         name_tag = { key: "Name", value: "our-app-instance-100" }
@@ -227,14 +230,16 @@ module SportNginAwsAuditor
                                                platform: nil,
                                                state: state,
                                                placement: placement,
-                                               class: "Aws::EC2::Types::Instance")
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-01')
         ec2_instance2 = double('ec2_instance', instance_id: "i-alsofake",
                                                instance_type: "t2.small",
                                                vpc_id: "vpc-alsofake",
                                                platform: "Windows",
                                                state: state,
                                                placement: placement,
-                                               class: "Aws::EC2::Types::Instance")
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-01')
         ec2_reservations = double('ec2_reservations', instances: [ec2_instance1, ec2_instance2])
         ec2_instances = double('ec2_instances', reservations: [ec2_reservations])
         name_tag = { key: "Name", value: "our-app-instance-100" }

--- a/spec/sport_ngin_aws_auditor/instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_spec.rb
@@ -3,26 +3,32 @@ require "sport_ngin_aws_auditor"
 module SportNginAwsAuditor
   describe Instance do
     it "should make a reserved instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", 4)
+      instance = Instance.new("Windows VPC us-east-1e m1.large", [4])
       expect(instance).to be_an_instance_of(Instance)
-      expect(instance.type).to eq("reserved")
+      expect(instance.category).to eq("reserved")
+      expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
       expect(instance.count).to eq(4)
       expect(instance.tagged?).to eq(false)
       expect(instance.reserved?).to eq(true)
     end
 
     it "should make a running instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", -1)
+      instance = Instance.new("Windows VPC us-east-1e m1.large", [-1])
       expect(instance).to be_an_instance_of(Instance)
-      expect(instance.type).to eq("running")
+      expect(instance.category).to eq("running")
+      expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
       expect(instance.count).to eq(-1.abs)
     end
 
     it "should make an instance with a tag with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", 4)
+      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", [4, 'example-instance-name', 'This is an example', '09/12/2015'])
       expect(instance).to be_an_instance_of(Instance)
-      expect(instance.type).to eq("tagged")
+      expect(instance.category).to eq("tagged")
+      expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
       expect(instance.count).to eq(4)
+      expect(instance.name).to eq('example-instance-name')
+      expect(instance.reason).to eq('This is an example')
+      expect(instance.tag_value).to eq('09/12/2015')
       expect(instance.tagged?).to eq(true)
       expect(instance.running?).to eq(false)
     end

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -22,14 +22,16 @@ module SportNginAwsAuditor
                                                db_instance_status: "available",
                                                engine: "mysql",
                                                availability_zone: "us-east-1a",
-                                               class: "Aws::RDS::Types::DBInstance")
+                                               class: "Aws::RDS::Types::DBInstance",
+                                               db_name: 'Example-instance-01')
         rds_instance2 = double('rds_instance', db_instance_identifier: "our-service",
                                                multi_az: false,
                                                db_instance_class: "db.m3.large",
                                                db_instance_status: "available",
                                                engine: "mysql",
                                                availability_zone: "us-east-1a",
-                                               class: "Aws::RDS::Types::DBInstance")
+                                               class: "Aws::RDS::Types::DBInstance",
+                                               db_name: 'Example-instance-01')
         db_instances = double('db_instances', db_instances: [rds_instance1, rds_instance2])
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
@@ -177,7 +179,8 @@ module SportNginAwsAuditor
                                               db_instance_status: "available",
                                               engine: "postgres",
                                               availability_zone: "us-east-1a",
-                                              class: "Aws::RDS::Types::DBInstance")
+                                              class: "Aws::RDS::Types::DBInstance",
+                                              db_name: 'Example-instance-01')
         db_instances = double('db_instances', db_instances: [rds_instance])
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")

--- a/spec/sport_ngin_aws_auditor/recently_retired_tag_spec.rb
+++ b/spec/sport_ngin_aws_auditor/recently_retired_tag_spec.rb
@@ -2,13 +2,28 @@ require "sport_ngin_aws_auditor"
 
 module SportNginAwsAuditor
   describe RecentlyRetiredTag do
-    it 'should have an instance name as an instance_name' do
-      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small')
-      expect(tag.instance_name).to eq('Linux VPC us-east-1b t2.small')
+    it 'should have an instance name as an instance_type' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small', 'Tag name', 'This is an example')
+      expect(tag.instance_type).to eq('Linux VPC us-east-1b t2.small')
+    end
+
+    it 'should have a name as the instance_name' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small', 'Tag name', 'This is an example')
+      expect(tag.instance_name).to eq('Tag name')
+    end
+
+    it 'should have a string description as the reason' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small', 'Tag name', 'This is an example')
+      expect(tag.reason).to eq('This is an example')
+    end
+
+    it 'should have nil as the reason' do
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small', 'Tag name')
+      expect(tag.reason).to eq(nil)
     end
 
     it 'should have a string date as a value' do
-      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small')
+      tag = RecentlyRetiredTag.new('09/01/2000', 'Linux VPC us-east-1b t2.small', 'Tag name')
       expect(tag.value).to eq('09/01/2000')
     end
   end

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '~> 1.3.0'
   spec.add_dependency 'activesupport', '~> 3.2'
   spec.add_dependency 'httparty'
+  spec.add_dependency 'colorize'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Description and Impact
----------------------
In the output of the expired EC2 tags:
* write name of the EC2 instance
* write value of the no-reserved-instance-reason (if exists)

In the output of the blue no-reserved-instance instances:
* write value of the no-reserved-instance-reason (if exists)
* the date on when to re-evaluate (the value of the tag)

Clarify whether the instances are unused, missing, or tagged as well as showing with colors.
```
Red: Unused RI
Yellow: Missing RI
Blue: No RI Yet
```

Deploy Plan
-----------
* merge into staging
* `op tag-release`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://stackoverflow.com/questions/1489183/colorized-ruby-output

QA Plan
-------
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` to see the output of the audit command
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]` to see the output of the audit command in Slack
- [x] Verify that the two commands match in output and verify that the above clarifications are appearing as they should
- [x] Do some regression testing:
  - [x] `GLI_DEBUG=true bin/sport-ngin-aws-auditor -e audit [account]`
  - [x] `GLI_DEBUG=true bin/sport-ngin-aws-auditor -r audit [account]`
  - [x] `GLI_DEBUG=true bin/sport-ngin-aws-auditor inspect [account]`