### PR TITLE
Fixing bugs so that counts are accurate again

### DIFF
--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -66,7 +66,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.reserved_instances_id
         self.name = nil
         self.platform = platform_helper(ec2_instance.product_description)
-        self.availability_zone = ec2_instance.availability_zone || '(region-based)'
+        self.availability_zone = ec2_instance.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil
@@ -75,7 +75,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.instance_id
         self.name = ec2_instance.key_name
         self.platform = platform_helper((ec2_instance.platform || ''), ec2_instance.vpc_id)
-        self.availability_zone = ec2_instance.placement.availability_zone ||'(region-based)'
+        self.availability_zone = ec2_instance.placement.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -66,7 +66,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.reserved_instances_id
         self.name = nil
         self.platform = platform_helper(ec2_instance.product_description)
-        self.availability_zone = ec2_instance.availability_zone
+        self.availability_zone = ec2_instance.availability_zone || '(region-based)'
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil
@@ -75,7 +75,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.instance_id
         self.name = ec2_instance.key_name
         self.platform = platform_helper((ec2_instance.platform || ''), ec2_instance.vpc_id)
-        self.availability_zone = ec2_instance.placement.availability_zone
+        self.availability_zone = ec2_instance.placement.availability_zone ||'(region-based)'
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -2,9 +2,9 @@ require_relative './recently_retired_tag'
 require_relative './audit_data'
 
 module SportNginAwsAuditor
-	module InstanceHelper
+  module InstanceHelper
 
-		def instance_hash
+    def instance_hash
       Hash[get_instances.map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 
@@ -16,7 +16,7 @@ module SportNginAwsAuditor
       instance_hash = Hash.new()
       instances.each do |instance|
         next if instance.nil?
-        instance_hash[instance.to_s] = instance_hash.has_key?(instance.to_s) ? instance_hash[instance.to_s][0] + instance.count : instance.count
+        instance_hash[instance.to_s] = instance_hash.has_key?(instance.to_s) ? instance_hash[instance.to_s] + instance.count : instance.count
       end if instances
 
       instance_hash.each do |key, value|
@@ -31,9 +31,9 @@ module SportNginAwsAuditor
         key = instance.to_s << " with tag"
         instance_result = []
         if instance_hash.has_key?(key)
-          instance_result << instance_hash[key][0] + 1
+          instance_result << instance_hash[key][0] + instance.count
         else
-          instance_result << 1
+          instance_result << instance.count
         end
         instance_result << instance.name
         instance_result << instance.tag_reason
@@ -107,5 +107,5 @@ module SportNginAwsAuditor
       end
       value
     end
-	end
+  end
 end


### PR DESCRIPTION
Description and Impact
----------------------
Fix bug where the counts of RIs and instances were off and the hashes weren't updating counts correctly.

Deploy Plan
-----------
* merge into staging
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` to see the output of the audit command and verify that the counts are correct