### PR TITLE
Handling region-based RIs

### DIFF
--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -65,7 +65,10 @@ module SportNginAwsAuditor
 
     def gather_region(instances)
       if self.klass == SportNginAwsAuditor.const_get('EC2Instance')
+        # if instances.first.availability_zone = 'us-east-1a'...
         match = instances.first.availability_zone.match(/(\w{2}-\w{4,})/)
+
+        # then region = 'us-east'
         self.region = match[0] unless match.nil?
       end
     end

--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -33,7 +33,7 @@ module SportNginAwsAuditor
 
       compared_array = []
       instance_hash.each do |key, value|
-        compared_array.push(Instance.new(key, value))
+        compared_array.push(Instance.new(key, value, self.region))
       end
 
       self.data = compared_array

--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -35,11 +35,12 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :instance_type, :scope, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(cache_instance, account_id=nil, tag_name=nil, cache=nil)
       if cache_instance.class.to_s == "Aws::ElastiCache::Types::ReservedCacheNode"
         self.id = cache_instance.reserved_cache_node_id
         self.name = cache_instance.reserved_cache_node_id
+        self.scope = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.product_description
         self.count = cache_instance.cache_node_count
@@ -47,6 +48,7 @@ module SportNginAwsAuditor
       elsif cache_instance.class.to_s == "Aws::ElastiCache::Types::CacheCluster"
         self.id = cache_instance.cache_cluster_id
         self.name = cache_instance.cache_cluster_id
+        self.scope = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.engine
         self.count = cache_instance.num_cache_nodes

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -9,6 +9,7 @@ command 'audit' do |c|
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
+  c.switch [:z, :zone_output], :desc => "Will print the Missing RIs and Tagged instances with zones"
   c.action do |global_options, options, args|
     require_relative '../scripts/audit'
     raise ArgumentError, 'You must specify an AWS account' unless args.first

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -23,9 +23,6 @@ module SportNginAwsAuditor
         return @reserved_instances if @reserved_instances
         @reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |instance|
           next unless instance.state == 'active'
-          # if instance.scope == 'Region'
-          #   puts "availability_zone: #{instance.availability_zone}"
-          # end
           new(instance, nil, instance.instance_count)
         end.compact
       end

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -23,6 +23,9 @@ module SportNginAwsAuditor
         return @reserved_instances if @reserved_instances
         @reserved_instances = ec2.describe_reserved_instances.reserved_instances.map do |instance|
           next unless instance.state == 'active'
+          # if instance.scope == 'Region'
+          #   puts "availability_zone: #{instance.availability_zone}"
+          # end
           new(instance, nil, instance.instance_count)
         end.compact
       end
@@ -60,13 +63,14 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id
         self.name = nil
         self.platform = platform_helper(ec2_instance.product_description)
-        self.availability_zone = ec2_instance.availability_zone
+        self.scope = ec2_instance.scope
+        self.availability_zone = self.scope == 'Region' ? nil : ec2_instance.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil
@@ -75,6 +79,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.instance_id
         self.name = ec2_instance.key_name
         self.platform = platform_helper((ec2_instance.platform || ''), ec2_instance.vpc_id)
+        self.scope = nil
         self.availability_zone = ec2_instance.placement.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count

--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -5,39 +5,44 @@ module SportNginAwsAuditor
     extend InstanceHelper
 
     attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based
-    def initialize(type, data_array, region)
+    def initialize(type, data_hash, region)
       if type.include?(" with tag")
         type = type.dup # because type is a frozen string right now
         type.slice!(" with tag")
         self.type = type
         self.category = "tagged"
-        self.name = data_array[1] || nil
-        self.reason = data_array[2] || nil
-        self.tag_value = data_array[3] || nil
-        self.region_based = false
+        self.name = data_hash[:name] || nil
+        self.reason = data_hash[:tag_reason] || nil
+        self.tag_value = data_hash[:tag_value] || nil
+        self.region_based = data_hash[:region_based] || nil
       else
-        self.region_based = data_array[1] || nil
+        self.region_based = data_hash[:region_based] || nil
 
-        if data_array[0] < 0
+        if data_hash[:count] < 0
           self.category = "running"
-        elsif data_array[0] == 0
+        elsif data_hash[:count] == 0
           self.category = "matched"
-        elsif data_array[0] > 0
+        elsif data_hash[:count] > 0
           self.category = "reserved"
         end
 
         if region_based?
+          # if type = 'Linux VPC  t2.small'...
           my_match = type.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
-          part1 = my_match[1] if my_match
-          part2 = my_match[2] if my_match
 
-          self.type = part1 << region << ' ' << part2
+          # then platform = 'Linux VPC '...
+          platform = my_match[1] if my_match
+
+          # and size = 't2.small'
+          size = my_match[2] if my_match
+
+          self.type = platform << region << ' ' << size
         else
           self.type = type
         end
       end
 
-      self.count = data_array[0].abs
+      self.count = data_hash[:count].abs
     end
 
     def region_based?

--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -4,8 +4,8 @@ module SportNginAwsAuditor
   class Instance
     extend InstanceHelper
 
-    attr_accessor :type, :count, :category, :tag_value, :reason, :name
-    def initialize(type, data_array)
+    attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based
+    def initialize(type, data_array, region)
       if type.include?(" with tag")
         type = type.dup # because type is a frozen string right now
         type.slice!(" with tag")
@@ -14,8 +14,9 @@ module SportNginAwsAuditor
         self.name = data_array[1] || nil
         self.reason = data_array[2] || nil
         self.tag_value = data_array[3] || nil
+        self.region_based = false
       else
-        self.type = type
+        self.region_based = data_array[1] || nil
 
         if data_array[0] < 0
           self.category = "running"
@@ -24,9 +25,23 @@ module SportNginAwsAuditor
         elsif data_array[0] > 0
           self.category = "reserved"
         end
+
+        if region_based?
+          my_match = type.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
+          part1 = my_match[1] if my_match
+          part2 = my_match[2] if my_match
+
+          self.type = part1 << region << ' ' << part2
+        else
+          self.type = type
+        end
       end
 
       self.count = data_array[0].abs
+    end
+
+    def region_based?
+      self.region_based
     end
 
     def tagged?

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -32,7 +32,7 @@ module SportNginAwsAuditor
         instance_result = {}
         
         if instance_hash.has_key?(key)
-          instance_result[:count] = instance_hash[:key][:count] + instance.count
+          instance_result[:count] = instance_hash[key][:count] + instance.count
         else
           instance_result[:count] = instance.count
         end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -59,6 +59,8 @@ module SportNginAwsAuditor
             end
           end
         end
+      end
+      ris_region.each do |ri|
         differences[ri.to_s] = [ri.count, true]
       end
     end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -36,7 +36,7 @@ module SportNginAwsAuditor
           instance_result[:count] = instance.count
         end
         instance_result.merge!({:name => instance.name, :tag_reason => instance.tag_reason,
-                               :tag_value => instance.tag_value, :region_based => false})
+                                :tag_value => instance.tag_value, :region_based => false})
         instance_hash[key] = instance_result
       end if instances_to_add
       instance_hash

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -48,7 +48,11 @@ module SportNginAwsAuditor
       instances_with_tag = filter_instances_with_tags(instances)
       instances_without_tag = filter_instance_without_tags(instances)
       instance_hash = instance_count_hash(instances_without_tag)
-      ris = instance_count_hash(get_reserved_instances)
+
+      ris = get_reserved_instances
+      ris_availability = filter_ris_availability_zone(ris)
+      ris_region = filter_ris_region_based(ris)
+      ris = instance_count_hash(ris_availability)
       
       instance_hash.keys.concat(ris.keys).uniq.each do |key|
         instance_count = instance_hash.has_key?(key) ? instance_hash[key][0] : 0
@@ -81,6 +85,18 @@ module SportNginAwsAuditor
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
         value.nil? || (Date.today.to_s >= value.to_s)
+      end
+    end
+
+    def filter_ris_availability_zone(ris)
+      ris.select do |ri|
+        ri.scope == 'Availability Zone'
+      end
+    end
+
+    def filter_ris_region_based(ris)
+      ris.select do |ri|
+        ri.scope == 'Region'
       end
     end
 

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -32,7 +32,7 @@ module SportNginAwsAuditor
         instance_result = {}
         
         if instance_hash.has_key?(key)
-          instance_result[:count] = instance_hash[:count] + instance.count
+          instance_result[:count] = instance_hash[:key][:count] + instance.count
         else
           instance_result[:count] = instance.count
         end

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -35,10 +35,11 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :multi_az, :scope, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
+        self.scope = nil
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.product_description)
@@ -47,6 +48,7 @@ module SportNginAwsAuditor
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
         self.name = rds_instance.db_name
+        self.scope = nil
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.engine)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -81,7 +81,7 @@ module SportNginAwsAuditor
       end
 
       def self.colorize(instance, zone_output=nil)
-        if !zone_output && (instance.tagged? || instance.reserved?)
+        if !zone_output && (instance.tagged? || instance.running?)
           name = instance.type.sub(/(-\d\w)/, '')
         else
           name = instance.type
@@ -136,7 +136,7 @@ module SportNginAwsAuditor
         slack_instances = NotifySlack.new(title)
 
         discrepancy_array.each do |discrepancy|
-          if !zone_output && discrepancy.reserved?
+          if !zone_output && discrepancy.running?
             type = discrepancy.type.sub(/(-\d\w)/, '')
           else
             type = discrepancy.type

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -66,7 +66,23 @@ module SportNginAwsAuditor
       def self.say_retired_ris(audit_results, output_options)
         retired_ris = audit_results.retired_ris
         say "The following reserved #{output_options[:class_type]}Instances have recently expired in #{output_options[:environment]}:"
-        retired_ris.each { |ri| say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}" }
+        retired_ris.each do |ri|
+          if ri.availability_zone.nil?
+            # if ri.to_s = 'Linux VPC  t2.small'...
+            my_match = ri.to_s.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
+
+            # then platform = 'Linux VPC '...
+            platform = my_match[1] if my_match
+
+            # and size = 't2.small'
+            size = my_match[2] if my_match
+
+            n = platform << audit_results.region << ' ' << size
+            say "#{n} (#{ri.count}) on #{ri.expiration_date}"
+          else
+            say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}"
+          end
+        end
       end
 
       def self.say_retired_tags(audit_results, output_options)
@@ -169,7 +185,21 @@ module SportNginAwsAuditor
         message = "The following reserved #{output_options[:class_type]}s have recently expired in #{output_options[:environment]}:\n"
 
         retired_ris.each do |ri|
-          name = ri.to_s
+          if ri.availability_zone.nil?
+            # if ri.to_s = 'Linux VPC  t2.small'...
+            my_match = ri.to_s.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
+
+            # then platform = 'Linux VPC '...
+            platform = my_match[1] if my_match
+
+            # and size = 't2.small'
+            size = my_match[2] if my_match
+
+            name = platform << audit_results.region << ' ' << size
+          else
+            name = ri.to_s
+          end
+          
           count = ri.count
           expiration_date = ri.expiration_date
           message << "*#{name}* (#{count}) on *#{expiration_date}*\n"

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -137,5 +137,13 @@ module SportNginAwsAuditor
         expect(result3).to eq(@retired_ris)
       end
     end
+
+    context '#gather_region' do
+      it 'should gather the region from an instance' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results.gather_region(@ec2_instances)
+        expect(audit_results.region).to eq('us-east')
+      end
+    end
   end
 end

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -14,10 +14,10 @@ module SportNginAwsAuditor
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
       allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_with_tags).and_return([])
-      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instance_without_tags).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_without_tags).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:instance_count_hash).and_return({'instance1' => 1,
                                                                                            'instance2' => 1})
-      allow(SportNginAwsAuditor::EC2Instance).to receive(:add_instances_with_tag_to_hash).and_return({'instance1' => 1,
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:apply_tagged_instances).and_return({'instance1' => 1,
                                                                                                       'instance2' => 1})
       allow(SportNginAwsAuditor::EC2Instance).to receive(:compare).and_return({'instance1' => 1,
                                                                                'instance2' => 1})

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -4,7 +4,7 @@ module SportNginAwsAuditor
   describe AuditData do
     before :each do
       @instance = double('instance')
-      @instance1 = double('ec2_instance1')
+      @instance1 = double('ec2_instance1', availability_zone: 'us-east-1b')
       @instance2 = double('ec2_instance2')
       @instance3 = double('ec2_instance3')
       @instance4 = double('ec2_instance4')

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -82,6 +82,7 @@ module SportNginAwsAuditor
                                                                  state: "active",
                                                                  availability_zone: "us-east-1b",
                                                                  instance_count: 4,
+                                                                 scope: 'Availability Zone',
                                                                  class: "Aws::EC2::Types::ReservedInstances")
         reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                  instance_type: "t2.small",
@@ -89,6 +90,7 @@ module SportNginAwsAuditor
                                                                  state: "active",
                                                                  availability_zone: "us-east-1b",
                                                                  instance_count: 2,
+                                                                 scope: 'Availability Zone',
                                                                  class: "Aws::EC2::Types::ReservedInstances")
         reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [reserved_ec2_instance1, reserved_ec2_instance2])
         ec2_client = double('ec2_client', describe_reserved_instances: reserved_ec2_instances)
@@ -134,6 +136,7 @@ module SportNginAwsAuditor
                                                                            state: "retired",
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 4,
+                                                                           scope: 'Availability Zone',
                                                                            class: "Aws::EC2::Types::ReservedInstances",
                                                                            end: @time - 86400)
           retired_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
@@ -142,6 +145,7 @@ module SportNginAwsAuditor
                                                                            state: "retired",
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 2,
+                                                                           scope: 'Availability Zone',
                                                                            class: "Aws::EC2::Types::ReservedInstances",
                                                                            end: @time - 86400)
           reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
@@ -150,6 +154,7 @@ module SportNginAwsAuditor
                                                                    state: "active",
                                                                    availability_zone: "us-east-1b",
                                                                    instance_count: 2,
+                                                                   scope: 'Availability Zone',
                                                                    class: "Aws::EC2::Types::ReservedInstances")
           reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [retired_reserved_ec2_instance1,
                                                                                          retired_reserved_ec2_instance2,

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -1,0 +1,167 @@
+require "sport_ngin_aws_auditor"
+
+module SportNginAwsAuditor
+  describe InstanceHelper do
+    before :each do
+      @ec2_instance1 = double('ec2_instance', instance_id: "i-thisisfake",
+                                               instance_type: "t2.small",
+                                               vpc_id: "vpc-alsofake",
+                                               platform: "Linux VPC",
+                                               state: nil,
+                                               placement: nil,
+                                               tags: nil,
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-01',
+                                               availability_zone: 'us-east-1b')
+      @ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
+                                               instance_type: "t2.medium",
+                                               vpc_id: "vpc-alsofake",
+                                               platform: "Windows",
+                                               state: nil,
+                                               placement: nil,
+                                               tags: nil,
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-02',
+                                               availability_zone: 'us-east-1b')
+      @reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
+                                                                instance_type: "t2.small",
+                                                                product_description: "Linux/UNIX (Amazon VPC)",
+                                                                state: "active",
+                                                                availability_zone: "us-east-1b",
+                                                                instance_count: 2,
+                                                                scope: 'Availability Zone',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
+                                                                instance_type: "t2.medium",
+                                                                product_description: "Windows",
+                                                                state: "active",
+                                                                availability_zone: "us-east-1b",
+                                                                instance_count: 4,
+                                                                scope: 'Availability Zone',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @region_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
+                                                                instance_type: "t2.small",
+                                                                product_description: "Linux/UNIX (Amazon VPC)",
+                                                                state: "active",
+                                                                availability_zone: nil,
+                                                                instance_count: 2,
+                                                                scope: 'Region',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @region_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
+                                                                instance_type: "t2.medium",
+                                                                product_description: "Windows",
+                                                                state: "active",
+                                                                availability_zone: nil,
+                                                                instance_count: 4,
+                                                                scope: 'Region',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @ec2_instances = [@ec2_instance1, @ec2_instance2]
+      @reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1]
+      @region_reserved_instances = [@region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
+      @all_reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1, @region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_instances).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@all_reserved_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
+      allow(@ec2_instance1).to receive(:count).and_return(1)
+      allow(@ec2_instance2).to receive(:count).and_return(1)
+      allow(@ec2_instance1).to receive(:to_s).and_return('Linux VPC us-east-1b t2.small')
+      allow(@ec2_instance2).to receive(:to_s).and_return('Windows us-east-1b t2.medium')
+      allow(@ec2_instance1).to receive(:name).and_return(@ec2_instance1.key_name)
+      allow(@ec2_instance2).to receive(:name).and_return(@ec2_instance2.key_name)
+      allow(@ec2_instance1).to receive(:tag_reason).and_return(nil)
+      allow(@ec2_instance2).to receive(:tag_reason).and_return(nil)
+      allow(@ec2_instance1).to receive(:tag_value).and_return(nil)
+      allow(@ec2_instance2).to receive(:tag_value).and_return(nil)
+      allow(@reserved_ec2_instance1).to receive(:count).and_return(2)
+      allow(@reserved_ec2_instance2).to receive(:count).and_return(2)
+      allow(@reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC us-east-1b t2.small')
+      allow(@reserved_ec2_instance2).to receive(:to_s).and_return('Windows us-east-1b t2.medium')
+      allow(@region_reserved_ec2_instance1).to receive(:platform).and_return('Linux VPC')
+      allow(@region_reserved_ec2_instance1).to receive(:instance_type).and_return('t2.small')
+      allow(@region_reserved_ec2_instance1).to receive(:count).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:platform).and_return('Windows')
+      allow(@region_reserved_ec2_instance2).to receive(:instance_type).and_return('t2.medium')
+      allow(@region_reserved_ec2_instance2).to receive(:count).and_return(4)
+      allow(@region_reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC  t2.small')
+      allow(@region_reserved_ec2_instance2).to receive(:to_s).and_return('Windows  t2.medium')
+    end
+
+    context '#instance_count_hash' do
+      it 'should add the instances to the hash of differences' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        result = klass.instance_count_hash(@ec2_instances)
+        expect(result).to eq({'Linux VPC us-east-1b t2.small' => [1, false], 'Windows us-east-1b t2.medium' => [1, false]})
+      end
+    end
+
+    context '#add_instances_with_tag_to_hash' do
+      it 'should add the instances to the hash of differences' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        result = klass.add_instances_with_tag_to_hash(@ec2_instances, {})
+        expect(result).to eq({'Linux VPC us-east-1b t2.small with tag' => [1, @ec2_instance1.key_name, nil, nil],
+                              'Windows us-east-1b t2.medium with tag' => [1, @ec2_instance2.key_name, nil, nil]})
+      end
+    end
+
+    context '#consider_region_ris' do
+      it 'should factor in the region based RIs into the counting when there is a mixture of region based and non region based' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        allow(@ec2_instance1).to receive(:count).and_return(5)
+        allow(@ec2_instance2).to receive(:count).and_return(5)
+        allow(@region_reserved_ec2_instance1).to receive(:count=)
+        allow(@region_reserved_ec2_instance2).to receive(:count=)
+        instance_hash = klass.instance_count_hash(@ec2_instances)
+        ris = klass.instance_count_hash(@reserved_instances)
+        differences = Hash.new()
+        instance_hash.keys.concat(ris.keys).uniq.each do |key|
+          instance_count = instance_hash.has_key?(key) ? instance_hash[key][0] : 0
+          ris_count = ris.has_key?(key) ? ris[key][0] : 0
+          differences[key] = [ris_count - instance_count, false]
+        end
+        result = klass.consider_region_ris(@region_reserved_instances, differences)
+        expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>[0, false], "Windows us-east-1b t2.medium"=>[0, false],
+                                   "Linux VPC  t2.small" => [2, true], "Windows  t2.medium" => [4, true]})
+      end
+
+      it 'should factor in the region based RIs into the counting when there are no zone specific RIs' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        allow(@ec2_instance1).to receive(:count).and_return(-2)
+        allow(@ec2_instance2).to receive(:count).and_return(5)
+        allow(@region_reserved_ec2_instance1).to receive(:count=)
+        allow(@region_reserved_ec2_instance2).to receive(:count=)
+        instance_hash = klass.instance_count_hash(@ec2_instances)
+        result = klass.consider_region_ris(@region_reserved_instances, instance_hash)
+        expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>[0, false], "Windows us-east-1b t2.medium"=>[5, false],
+                                     "Linux VPC  t2.small" => [2, true], "Windows  t2.medium" => [4, true]})
+      end
+    end
+
+    context '#filter_ris_region_based' do
+      it 'should filter all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        result = klass.filter_ris_region_based(@all_reserved_instances)
+        expect(result).to eq(@region_reserved_instances)
+      end
+    end
+
+    context '#filter_ris_availability_zone' do
+      it 'should remove all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        result = klass.filter_ris_availability_zone(@all_reserved_instances)
+        expect(result).to eq(@reserved_instances)
+      end
+    end
+
+    context '#gather_instance_tag_date' do
+      it 'should remove all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        allow(@ec2_instance1).to receive(:no_reserved_instance_tag_value).and_return('08/29/1995')
+        result = klass.gather_instance_tag_date(@ec2_instance1)
+        date_hash = Date._strptime('08/29/1995', '%m/%d/%Y')
+        value = Date.new(date_hash[:year], date_hash[:mon], date_hash[:mday]) if date_hash
+        expect(result).to eq(value)
+      end
+    end
+
+  end
+end

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -88,24 +88,24 @@ module SportNginAwsAuditor
 
     context '#instance_count_hash' do
       it 'should add the instances to the hash of differences' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         result = klass.instance_count_hash(@ec2_instances)
         expect(result).to eq({'Linux VPC us-east-1b t2.small' => {count: 1, region_based: false}, 'Windows us-east-1b t2.medium' => {count: 1, region_based: false}})
       end
     end
 
-    context '#add_instances_with_tag_to_hash' do
+    context '#apply_tagged_instances' do
       it 'should add the instances to the hash of differences' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
-        result = klass.add_instances_with_tag_to_hash(@ec2_instances, {})
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.apply_tagged_instances(@ec2_instances, {})
         expect(result).to eq({'Linux VPC us-east-1b t2.small with tag' => {count: 1, name: @ec2_instance1.key_name, tag_reason: nil, tag_value: nil, region_based: false},
                               'Windows us-east-1b t2.medium with tag' => {count: 1, name: @ec2_instance2.key_name, tag_reason: nil, tag_value: nil, region_based: false}})
       end
     end
 
-    context '#consider_region_ris' do
+    context '#apply_region_ris' do
       it 'should factor in the region based RIs into the counting when there is a mixture of region based and non region based' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         allow(@ec2_instance1).to receive(:count).and_return(5)
         allow(@ec2_instance2).to receive(:count).and_return(5)
         allow(@region_reserved_ec2_instance1).to receive(:count=)
@@ -118,19 +118,19 @@ module SportNginAwsAuditor
           ris_count = ris.has_key?(key) ? ris[key][:count] : 0
           differences[key] = {count: ris_count - instance_count, region_based: false}
         end
-        result = klass.consider_region_ris(@region_reserved_instances, differences)
+        result = klass.apply_region_ris(@region_reserved_instances, differences)
         expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 0, region_based: false},
                                    "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end
 
       it 'should factor in the region based RIs into the counting when there are no zone specific RIs' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         allow(@ec2_instance1).to receive(:count).and_return(-2)
         allow(@ec2_instance2).to receive(:count).and_return(5)
         allow(@region_reserved_ec2_instance1).to receive(:count=)
         allow(@region_reserved_ec2_instance2).to receive(:count=)
         instance_hash = klass.instance_count_hash(@ec2_instances)
-        result = klass.consider_region_ris(@region_reserved_instances, instance_hash)
+        result = klass.apply_region_ris(@region_reserved_instances, instance_hash)
         expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 5, region_based: false},
                                      "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end
@@ -138,7 +138,7 @@ module SportNginAwsAuditor
 
     context '#filter_ris_region_based' do
       it 'should filter all of the region based RIs out of the entire RI list' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         result = klass.filter_ris_region_based(@all_reserved_instances)
         expect(result).to eq(@region_reserved_instances)
       end
@@ -146,7 +146,7 @@ module SportNginAwsAuditor
 
     context '#filter_ris_availability_zone' do
       it 'should remove all of the region based RIs out of the entire RI list' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         result = klass.filter_ris_availability_zone(@all_reserved_instances)
         expect(result).to eq(@reserved_instances)
       end
@@ -154,7 +154,7 @@ module SportNginAwsAuditor
 
     context '#gather_instance_tag_date' do
       it 'should remove all of the region based RIs out of the entire RI list' do
-        klass = SportNginAwsAuditor.const_get('EC2Instance')
+        klass = SportNginAwsAuditor::EC2Instance
         allow(@ec2_instance1).to receive(:no_reserved_instance_tag_value).and_return('08/29/1995')
         result = klass.gather_instance_tag_date(@ec2_instance1)
         date_hash = Date._strptime('08/29/1995', '%m/%d/%Y')

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -98,8 +98,8 @@ module SportNginAwsAuditor
       it 'should add the instances to the hash of differences' do
         klass = SportNginAwsAuditor::EC2Instance
         result = klass.apply_tagged_instances(@ec2_instances, {})
-        expect(result).to eq({'Linux VPC us-east-1b t2.small with tag' => {count: 1, name: @ec2_instance1.key_name, tag_reason: nil, tag_value: nil, region_based: false},
-                              'Windows us-east-1b t2.medium with tag' => {count: 1, name: @ec2_instance2.key_name, tag_reason: nil, tag_value: nil, region_based: false}})
+        expect(result).to eq({'Linux VPC us-east-1b t2.small with tag (Example-instance-01)' => {count: 1, name: @ec2_instance1.key_name, tag_reason: nil, tag_value: nil, region_based: false},
+                              'Windows us-east-1b t2.medium with tag (Example-instance-02)' => {count: 1, name: @ec2_instance2.key_name, tag_reason: nil, tag_value: nil, region_based: false}})
       end
     end
 

--- a/spec/sport_ngin_aws_auditor/instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_spec.rb
@@ -3,7 +3,7 @@ require "sport_ngin_aws_auditor"
 module SportNginAwsAuditor
   describe Instance do
     it "should make a reserved instance with proper attributes" do
-      instance = Instance.new("Windows VPC  m1.large", [4, true], 'us-east')
+      instance = Instance.new("Windows VPC  m1.large", {count: 4, region_based: true}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("reserved")
       expect(instance.type).to eq("Windows VPC us-east m1.large")
@@ -13,7 +13,7 @@ module SportNginAwsAuditor
     end
 
     it "should make a running instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", [-1, false], 'us-east')
+      instance = Instance.new("Windows VPC us-east-1e m1.large", {count: -1, region_based: false}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("running")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
@@ -21,7 +21,7 @@ module SportNginAwsAuditor
     end
 
     it "should make an instance with a tag with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", [4, 'example-instance-name', 'This is an example', '09/12/2015'], 'us-east')
+      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", {count: 4, name: 'example-instance-name', tag_reason: 'This is an example', tag_value: '09/12/2015', region_based: false}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("tagged")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")

--- a/spec/sport_ngin_aws_auditor/instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_spec.rb
@@ -3,17 +3,17 @@ require "sport_ngin_aws_auditor"
 module SportNginAwsAuditor
   describe Instance do
     it "should make a reserved instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", [4])
+      instance = Instance.new("Windows VPC  m1.large", [4, true], 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("reserved")
-      expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
+      expect(instance.type).to eq("Windows VPC us-east m1.large")
       expect(instance.count).to eq(4)
       expect(instance.tagged?).to eq(false)
       expect(instance.reserved?).to eq(true)
     end
 
     it "should make a running instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", [-1])
+      instance = Instance.new("Windows VPC us-east-1e m1.large", [-1, false], 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("running")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
@@ -21,7 +21,7 @@ module SportNginAwsAuditor
     end
 
     it "should make an instance with a tag with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", [4, 'example-instance-name', 'This is an example', '09/12/2015'])
+      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", [4, 'example-instance-name', 'This is an example', '09/12/2015'], 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("tagged")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")


### PR DESCRIPTION
## Description and Impact

This will take reserved EC2Instances into account if they are region-based (if they have no zone-specific). It first does the original math and counting for zone-specific instances and RIs, and then last factors in if they are region-based. It also offers a couple of different printing techniques for whether we are using region-based RIs or not. If a RI is region-based, then it will only print the region (not the zone). If a RI is zone-specific, then it will continue to print the zone. For Missing RI and Tagged RI outputs, then there is a new option (`-z` or `--zone_output`) that will tell the program to print the zones to the outputs, otherwise it will just print regions.

\* To run this, the version of aws-sdk must be at 2.6.6 or higher.

## Deploy Plan
Does Platform Operations need to know anything special about this deploy? Are migrations present?

## Rollback Plan
- To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## URLs 
Links to bug tickets or user stories.

## QA Plan
- [ ] Run command to print region-based data in terminal: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]`
- [ ] Run command to print zone-based data in terminal: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -z [account]`
- [ ] Run command to print region-based data into Slack: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]`
- [ ] Run command to print zone-based data into Slack: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s -z [account]`
- [ ] Do something to test that region-based RIs are printing correctly and correct math is being done.
