### PR TITLE
Tagged output should include name, only one tagged output per line, Unused RI list should take tagged instances into account

### DIFF
--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -3,7 +3,7 @@ require_relative './instance_helper'
 module SportNginAwsAuditor
   class AuditData
 
-    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name
+    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region
     def initialize(instances, reserved, class_type, tag_name)
       self.selected_audit_type = (!instances && !reserved) ? "all" : (instances ? "instances" : "reserved")
       self.klass = SportNginAwsAuditor.const_get(class_type)
@@ -25,15 +25,17 @@ module SportNginAwsAuditor
     def gather_data
       if instances?
         instance_hash, retired_tags = gather_instances_data
+        retired_ris = nil
       elsif reserved?
         instance_hash = self.klass.instance_count_hash(self.klass.get_reserved_instances)
+        retired_tags, retired_ris = nil
       elsif all?
         instance_hash, retired_tags, retired_ris = gather_all_data
       end
 
       compared_array = []
       instance_hash.each do |key, value|
-        compared_array.push(Instance.new(key, value))
+        compared_array.push(Instance.new(key, value, self.region))
       end
 
       self.data = compared_array
@@ -43,22 +45,34 @@ module SportNginAwsAuditor
 
     def gather_instances_data
       instances = self.klass.get_instances(tag_name)
+      gather_region(instances)
       retired_tags = self.klass.get_retired_tags(instances)
       instances_with_tag = self.klass.filter_instances_with_tags(instances)
-      instances_without_tag = self.klass.filter_instance_without_tags(instances)
+      instances_without_tag = self.klass.filter_instances_without_tags(instances)
       instance_hash = self.klass.instance_count_hash(instances_without_tag)
-      self.klass.add_instances_with_tag_to_hash(instances_with_tag, instance_hash)
+      self.klass.apply_tagged_instances(instances_with_tag, instance_hash)
 
       return instance_hash, retired_tags
     end
 
     def gather_all_data
       instances = self.klass.get_instances(tag_name)
+      gather_region(instances)
       retired_tags = self.klass.get_retired_tags(instances)
       instance_hash = self.klass.compare(instances)
       retired_ris = self.klass.get_recent_retired_reserved_instances
 
       return instance_hash, retired_tags, retired_ris
+    end
+
+    def gather_region(instances)
+      if self.klass == SportNginAwsAuditor::EC2Instance
+        # if instances.first.availability_zone = 'us-east-1a'...
+        match = instances.first.availability_zone.match(/(\w{2}-\w{4,})/)
+
+        # then region = 'us-east'
+        self.region = match[0] unless match.nil?
+      end
     end
   end
 end

--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -35,11 +35,12 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :instance_type, :scope, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(cache_instance, account_id=nil, tag_name=nil, cache=nil)
       if cache_instance.class.to_s == "Aws::ElastiCache::Types::ReservedCacheNode"
         self.id = cache_instance.reserved_cache_node_id
         self.name = cache_instance.reserved_cache_node_id
+        self.scope = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.product_description
         self.count = cache_instance.cache_node_count
@@ -47,6 +48,7 @@ module SportNginAwsAuditor
       elsif cache_instance.class.to_s == "Aws::ElastiCache::Types::CacheCluster"
         self.id = cache_instance.cache_cluster_id
         self.name = cache_instance.cache_cluster_id
+        self.scope = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.engine
         self.count = cache_instance.num_cache_nodes

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -9,6 +9,7 @@ command 'audit' do |c|
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
+  c.switch [:z, :zone_output], :desc => "Will print the Missing RIs and Tagged instances with zones"
   c.action do |global_options, options, args|
     require_relative '../scripts/audit'
     raise ArgumentError, 'You must specify an AWS account' unless args.first

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -60,13 +60,14 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id
         self.name = nil
         self.platform = platform_helper(ec2_instance.product_description)
-        self.availability_zone = ec2_instance.availability_zone
+        self.scope = ec2_instance.scope
+        self.availability_zone = self.scope == 'Region' ? nil : ec2_instance.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count
         self.stack_name = nil
@@ -75,6 +76,7 @@ module SportNginAwsAuditor
         self.id = ec2_instance.instance_id
         self.name = ec2_instance.key_name
         self.platform = platform_helper((ec2_instance.platform || ''), ec2_instance.vpc_id)
+        self.scope = nil
         self.availability_zone = ec2_instance.placement.availability_zone
         self.instance_type = ec2_instance.instance_type
         self.count = count

--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -4,29 +4,49 @@ module SportNginAwsAuditor
   class Instance
     extend InstanceHelper
 
-    attr_accessor :type, :count, :category, :tag_value, :reason, :name
-    def initialize(type, data_array)
+    attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based
+    def initialize(type, data_hash, region)
       if type.include?(" with tag")
         type = type.dup # because type is a frozen string right now
         type.slice!(" with tag")
         self.type = type
         self.category = "tagged"
-        self.name = data_array[1] || nil
-        self.reason = data_array[2] || nil
-        self.tag_value = data_array[3] || nil
+        self.name = data_hash[:name] || nil
+        self.reason = data_hash[:tag_reason] || nil
+        self.tag_value = data_hash[:tag_value] || nil
+        self.region_based = data_hash[:region_based] || nil
       else
-        self.type = type
+        self.region_based = data_hash[:region_based] || nil
 
-        if data_array[0] < 0
+        if data_hash[:count] < 0
           self.category = "running"
-        elsif data_array[0] == 0
+        elsif data_hash[:count] == 0
           self.category = "matched"
-        elsif data_array[0] > 0
+        elsif data_hash[:count] > 0
           self.category = "reserved"
+        end
+
+        if region_based?
+          # if type = 'Linux VPC  t2.small'...
+          my_match = type.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
+
+          # then platform = 'Linux VPC '...
+          platform = my_match[1] if my_match
+
+          # and size = 't2.small'
+          size = my_match[2] if my_match
+
+          self.type = platform << region << ' ' << size
+        else
+          self.type = type
         end
       end
 
-      self.count = data_array[0].abs
+      self.count = data_hash[:count].abs
+    end
+
+    def region_based?
+      self.region_based
     end
 
     def tagged?

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -20,52 +20,88 @@ module SportNginAwsAuditor
       end if instances
 
       instance_hash.each do |key, value|
-        instance_hash[key] = [instance_hash[key]]
+        instance_hash[key] = {:count => instance_hash[key], :region_based => false}
       end
       instance_hash
     end
 
-    def add_instances_with_tag_to_hash(instances_to_add, instance_hash)
+    def apply_tagged_instances(instances_to_add, instance_hash)
       instances_to_add.each do |instance|
         next if instance.nil?
         key = instance.to_s.dup << " with tag (" << instance.name << ")"
-        instance_result = []
+        instance_result = {}
         
-        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][0] > 0
-          current_val = instance_hash[instance.to_s][0]
+        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0
+          current_val = instance_hash[instance.to_s][:count]
           val = current_val - instance.count
           new_val = val >= 0 ? val : 0
-          instance_hash[instance.to_s][0] = new_val
+          instance_hash[instance.to_s][:count] = new_val
 
           val = instance.count - current_val
           new_val = val >= 0 ? val : 0
-          instance_result << new_val
+          instance_result[:count] = new_val
         else
-          instance_result << instance.count
+          instance_result[:count] = instance.count
         end
 
-        instance_result << instance.name
-        instance_result << instance.tag_reason
-        instance_result << instance.tag_value
+        instance_result.merge!({:name => instance.name, :tag_reason => instance.tag_reason,
+                                :tag_value => instance.tag_value, :region_based => false})
         instance_hash[key] = instance_result
       end if instances_to_add
       instance_hash
     end
 
-    def compare(instances)
-      differences = Hash.new()
-      instances_with_tag = filter_instances_with_tags(instances)
-      instances_without_tag = filter_instance_without_tags(instances)
-      instance_hash = instance_count_hash(instances_without_tag)
-      ris = instance_count_hash(get_reserved_instances)
-      
-      instance_hash.keys.concat(ris.keys).uniq.each do |key|
-        instance_count = instance_hash.has_key?(key) ? instance_hash[key][0] : 0
-        ris_count = ris.has_key?(key) ? ris[key][0] : 0
-        differences[key] = [ris_count - instance_count]
+    def apply_region_ris(ris_region, differences)
+      ris_region.each do |ri|
+        differences.each do |key, value|
+          # if key = 'Linux VPC us-east-1a t2.medium'...
+          my_match = key.match(/(\w*\s*\w*\s*)\w{2}-\w{2,}-\w{2}(\s*\S*)/)
+
+          # then platform = 'Linux VPC'...
+          platform = my_match[1] if my_match
+          platform[platform.length - 1] = ''
+
+          # and size = 't2.medium'
+          size = my_match[2] if my_match
+          size[0] = ''
+
+          if (platform == ri.platform) && (size == ri.instance_type) && (value[:count] < 0)
+            until (ri.count == 0) || (value[:count] == 0)
+              value[:count] = value[:count] + 1
+              ri.count = ri.count - 1
+            end
+          end
+        end
       end
+
+      ris_region.each do |ri|
+        differences[ri.to_s] = {:count => ri.count, :region_based => true}
+      end
+    end
+
+    def measure_differences(instance_hash, ris_hash)
+      differences = Hash.new()
+      instance_hash.keys.concat(ris_hash.keys).uniq.each do |key|
+        instance_count = instance_hash.has_key?(key) ? instance_hash[key][:count] : 0
+        ris_count = ris_hash.has_key?(key) ? ris_hash[key][:count] : 0
+        differences[key] = {:count => ris_count - instance_count, :region_based => false}
+      end
+      differences
+    end
+
+    def compare(instances)
+      instances_with_tag = filter_instances_with_tags(instances)
+      instances_without_tag = filter_instances_without_tags(instances)
+      instance_hash = instance_count_hash(instances_without_tag)
+
+      ris = get_reserved_instances
+      ris_availability = filter_ris_availability_zone(ris)
+      ris_region = filter_ris_region_based(ris)
+      ris_hash = instance_count_hash(ris_availability)
       
-      add_instances_with_tag_to_hash(instances_with_tag, differences)
+      differences = measure_differences(instance_hash, ris_hash)
+      apply_region_ris(ris_region, differences)
+      apply_tagged_instances(instances_with_tag, differences)
       differences
     end
 
@@ -86,11 +122,21 @@ module SportNginAwsAuditor
     end
 
     # assuming the value of the tag is in the form: 01/01/2000 like a date
-    def filter_instance_without_tags(instances)
+    def filter_instances_without_tags(instances)
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
         value.nil? || (Date.today.to_s >= value.to_s)
       end
+    end
+
+    # this gathers all RIs except the region-based RIs
+    def filter_ris_availability_zone(ris)
+      ris.reject { |ri| ri.scope == 'Region' }
+    end
+
+    # this filters all of the region-based RIs
+    def filter_ris_region_based(ris)
+      ris.select { |ri| ri.scope == 'Region' }
     end
 
     # this returns a hash of all instances that have retired between 1 week ago and today

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -26,15 +26,29 @@ module SportNginAwsAuditor
     end
 
     def add_instances_with_tag_to_hash(instances_to_add, instance_hash)
+      puts "hello"
       instances_to_add.each do |instance|
         next if instance.nil?
-        key = instance.to_s << " with tag"
+        key = instance.to_s.dup << " with tag"
         instance_result = []
-        if instance_hash.has_key?(key)
-          instance_result << instance_hash[key][0] + instance.count
+        
+        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][0] > 0
+          current_val = instance_hash[instance.to_s][0]
+          val = current_val - instance.count
+          new_val = val >= 0 ? val : 0
+          instance_hash[instance.to_s][0] = new_val
+
+          val = instance.count - current_val
+          new_val = val >= 0 ? val : 0
+          instance_result << new_val
         else
-          instance_result << instance.count
+          if instance_hash.has_key?(key)
+            instance_result << instance_hash[key][0] + instance.count
+          else
+            instance_result << instance.count
+          end
         end
+
         instance_result << instance.name
         instance_result << instance.tag_reason
         instance_result << instance.tag_value

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -26,10 +26,9 @@ module SportNginAwsAuditor
     end
 
     def add_instances_with_tag_to_hash(instances_to_add, instance_hash)
-      puts "hello"
       instances_to_add.each do |instance|
         next if instance.nil?
-        key = instance.to_s.dup << " with tag"
+        key = instance.to_s.dup << " with tag (" << instance.name << ")"
         instance_result = []
         
         if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][0] > 0
@@ -42,11 +41,7 @@ module SportNginAwsAuditor
           new_val = val >= 0 ? val : 0
           instance_result << new_val
         else
-          if instance_hash.has_key?(key)
-            instance_result << instance_hash[key][0] + instance.count
-          else
-            instance_result << instance.count
-          end
+          instance_result << instance.count
         end
 
         instance_result << instance.name

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -146,7 +146,7 @@ module SportNginAwsAuditor
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
         one_week_ago = (Date.today - 7).to_s
-        if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
+        if (value && (one_week_ago < value.to_s) && (value.to_s <= Date.today.to_s))
           return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name, instance.tag_reason)
         end
       end

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -35,10 +35,11 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :multi_az, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :multi_az, :scope, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
     def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
+        self.scope = nil
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.product_description)
@@ -47,6 +48,7 @@ module SportNginAwsAuditor
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
         self.name = rds_instance.db_name
+        self.scope = nil
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.engine)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -25,6 +25,8 @@ module SportNginAwsAuditor
           tag_name = options[:tag]
         end
 
+        zone_output = options[:zone_output]
+
         cycle = [["EC2Instance", options[:ec2]],
                  ["RDSInstance", options[:rds]],
                  ["CacheInstance", options[:cache]]]
@@ -38,37 +40,38 @@ module SportNginAwsAuditor
         cycle.each do |c|
           audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name)
           audit_results.gather_data
-          print_data(slack, audit_results, c.first, environment) if (c.last || no_selection)
+          output_options = {:slack => slack, :class_type => c.first,
+                            :environment => environment, :zone_output => zone_output}
+          print_data(audit_results, output_options) if (c.last || no_selection)
         end
       end
 
-      def self.print_data(slack, audit_results, class_type, environment)
+      def self.print_data(audit_results, output_options)
         audit_results.data.sort_by! { |instance| [instance.category, instance.type] }
 
-        if slack
-          print_to_slack(audit_results, class_type, environment)
+        if output_options[:slack]
+          print_to_slack(audit_results, output_options)
         elsif options[:reserved] || options[:instances]
-          puts header(class_type)
+          puts header(output_options[:class_type])
           audit_results.data.each{ |instance| say "<%= color('#{instance.type}: #{instance.count}', :white) %>" }
         else
-          retired_ris = audit_results.retired_ris
-          retired_tags = audit_results.retired_tags
+          puts header(output_options[:class_type])
+          audit_results.data.each{ |instance| colorize(instance, output_options[:zone_output]) }
 
-          puts header(class_type)
-          audit_results.data.each{ |instance| colorize(instance) }
-
-          say_retired_ris(retired_ris, class_type, environment) unless retired_ris.empty?
-          say_retired_tags(retired_tags, class_type, environment) unless retired_tags.empty?
+          say_retired_ris(audit_results, output_options) unless audit_results.retired_ris.empty?
+          say_retired_tags(audit_results, output_options) unless audit_results.retired_tags.empty?
         end
       end
 
-      def self.say_retired_ris(retired_ris, class_type, environment)
-        say "The following reserved #{class_type}Instances have recently expired in #{environment}:"
+      def self.say_retired_ris(audit_results, output_options)
+        retired_ris = audit_results.retired_ris
+        say "The following reserved #{output_options[:class_type]}Instances have recently expired in #{output_options[:environment]}:"
         retired_ris.each { |ri| say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}" }
       end
 
-      def self.say_retired_tags(retired_tags, class_type, environment)
-        say "The following #{class_type}Instance tags have recently expired in #{environment}:"
+      def self.say_retired_tags(audit_results, output_options)
+        retired_tags = audit_results.retired_tags
+        say "The following #{output_options[:class_type]}Instance tags have recently expired in #{output_options[:environment]}:"
         retired_tags.each do |tag|
           if tag.reason
             say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because of #{tag.reason}"
@@ -78,10 +81,11 @@ module SportNginAwsAuditor
         end
       end
 
-      def self.colorize(instance)
-        name = instance.type
+      def self.colorize(instance, zone_output=nil)
+        name = !zone_output && (instance.tagged? || instance.running?) ? print_without_zone(instance.type) : instance.type
         count = instance.count
         color, rgb, prefix = color_chooser(instance)
+        
         if instance.tagged?
           if instance.reason
             puts "#{prefix} #{name} (expiring on #{instance.tag_value} because of #{instance.reason})".blue
@@ -93,7 +97,7 @@ module SportNginAwsAuditor
         end
       end
 
-      def self.print_to_slack(audit_results, class_type, environment)
+      def self.print_to_slack(audit_results, output_options)
         discrepancy_array = []
         tagged_array = []
 
@@ -104,32 +108,29 @@ module SportNginAwsAuditor
         end
 
         unless discrepancy_array.empty?
-          print_discrepancies(discrepancy_array, audit_results, class_type, environment)
+          print_discrepancies(discrepancy_array, output_options)
         end
 
-        audit_results.data.each do |instance|
+       audit_results.data.each do |instance|
           if instance.tagged?
             tagged_array.push(instance)
           end
         end
 
         unless tagged_array.empty?
-          print_tagged(tagged_array, audit_results, class_type, environment)
+          print_tagged(tagged_array, output_options)
         end
 
-        retired_ris = audit_results.retired_ris
-        retired_tags = audit_results.retired_tags
-
-        print_retired_ris(retired_ris, class_type, environment) unless retired_ris.empty?
-        print_retired_tags(retired_tags, class_type, environment) unless retired_tags.empty?
+        print_retired_ris(audit_results, output_options) unless audit_results.retired_ris.empty?
+        print_retired_tags(audit_results, output_options) unless audit_results.retired_tags.empty?
       end
 
-      def self.print_discrepancies(discrepancy_array, audit_results, class_type, environment)
-        title = "Some #{class_type} discrepancies for #{environment} exist:\n"
+      def self.print_discrepancies(discrepancy_array, output_options)
+        title = "Some #{output_options[:class_type]} discrepancies for #{output_options[:environment]} exist:\n"
         slack_instances = NotifySlack.new(title)
 
         discrepancy_array.each do |discrepancy|
-          type = discrepancy.type
+          type = !output_options[:zone_output] && discrepancy.running? ? print_without_zone(discrepancy.type) : discrepancy.type
           count = discrepancy.count
           color, rgb, prefix = color_chooser(discrepancy)
 
@@ -142,12 +143,12 @@ module SportNginAwsAuditor
         slack_instances.perform        
       end
 
-      def self.print_tagged(tagged_array, audit_results, class_type, environment)
-        title = "There are currently some tagged #{class_type}s in #{environment}:\n"
+      def self.print_tagged(tagged_array, output_options)
+        title = "There are currently some tagged #{output_options[:class_type]}s in #{output_options[:environment]}:\n"
         slack_instances = NotifySlack.new(title)
 
         tagged_array.each do |tagged|
-          type = tagged.type
+          type = output_options[:zone_output] ? tagged.type : print_without_zone(tagged.type)
           count = tagged.count
           color, rgb, prefix = color_chooser(tagged)
           
@@ -163,8 +164,9 @@ module SportNginAwsAuditor
         slack_instances.perform
       end
 
-      def self.print_retired_ris(retired_ris, class_type, environment)
-        message = "The following reserved #{class_type}s have recently expired in #{environment}:\n"
+      def self.print_retired_ris(audit_results, output_options)
+        retired_ris = audit_results.retired_ris
+        message = "The following reserved #{output_options[:class_type]}s have recently expired in #{output_options[:environment]}:\n"
 
         retired_ris.each do |ri|
           name = ri.to_s
@@ -177,8 +179,9 @@ module SportNginAwsAuditor
         slack_retired_ris.perform
       end
 
-      def self.print_retired_tags(retired_tags, class_type, environment)
-        message = "The following #{class_type} tags have recently expired in #{environment}:\n"
+      def self.print_retired_tags(audit_results, output_options)
+        retired_tags = audit_results.retired_tags
+        message = "The following #{output_options[:class_type]} tags have recently expired in #{output_options[:environment]}:\n"
 
         retired_tags.each do |tag|
           if tag.reason
@@ -190,6 +193,10 @@ module SportNginAwsAuditor
 
         slack_retired_tags = NotifySlack.new(message)
         slack_retired_tags.perform
+      end
+
+      def self.print_without_zone(type)
+        type.sub(/(-\d\w)/, '')
       end
 
       def self.color_chooser(instance)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -84,9 +84,9 @@ module SportNginAwsAuditor
         color, rgb, prefix = color_chooser(instance)
         if instance.tagged?
           if instance.reason
-            puts "#{prefix} #{name}: #{count} (expiring on #{instance.tag_value} because of #{instance.reason})".blue
+            puts "#{prefix} #{name} (expiring on #{instance.tag_value} because of #{instance.reason})".blue
           else
-            say "<%= color('#{prefix} #{name}: #{count} (expiring on #{instance.tag_value})', :#{color}) %>"
+            say "<%= color('#{prefix} #{name} (expiring on #{instance.tag_value})', :#{color}) %>"
           end
         else
           say "<%= color('#{prefix} #{name}: #{count}', :#{color}) %>"
@@ -152,7 +152,7 @@ module SportNginAwsAuditor
           color, rgb, prefix = color_chooser(tagged)
           
           if tagged.reason
-            text = "#{prefix} #{type}: #{count} (expiring on #{tagged.tag_value} because of #{tagged.reason})"
+            text = "#{prefix} #{type} (expiring on #{tagged.tag_value} because of #{tagged.reason})"
           else
             text = "#{prefix} #{type}: #{count} (expiring on #{tagged.tag_value})"
           end

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -4,7 +4,7 @@ module SportNginAwsAuditor
   describe AuditData do
     before :each do
       @instance = double('instance')
-      @instance1 = double('ec2_instance1')
+      @instance1 = double('ec2_instance1', availability_zone: 'us-east-1b')
       @instance2 = double('ec2_instance2')
       @instance3 = double('ec2_instance3')
       @instance4 = double('ec2_instance4')
@@ -14,10 +14,10 @@ module SportNginAwsAuditor
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
       allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_with_tags).and_return([])
-      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instance_without_tags).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_without_tags).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:instance_count_hash).and_return({'instance1' => 1,
                                                                                            'instance2' => 1})
-      allow(SportNginAwsAuditor::EC2Instance).to receive(:add_instances_with_tag_to_hash).and_return({'instance1' => 1,
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:apply_tagged_instances).and_return({'instance1' => 1,
                                                                                                       'instance2' => 1})
       allow(SportNginAwsAuditor::EC2Instance).to receive(:compare).and_return({'instance1' => 1,
                                                                                'instance2' => 1})
@@ -135,6 +135,14 @@ module SportNginAwsAuditor
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
         expect(result3).to eq(@retired_ris)
+      end
+    end
+
+    context '#gather_region' do
+      it 'should gather the region from an instance' do
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results.gather_region(@ec2_instances)
+        expect(audit_results.region).to eq('us-east')
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -82,6 +82,7 @@ module SportNginAwsAuditor
                                                                  state: "active",
                                                                  availability_zone: "us-east-1b",
                                                                  instance_count: 4,
+                                                                 scope: 'Availability Zone',
                                                                  class: "Aws::EC2::Types::ReservedInstances")
         reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                  instance_type: "t2.small",
@@ -89,6 +90,7 @@ module SportNginAwsAuditor
                                                                  state: "active",
                                                                  availability_zone: "us-east-1b",
                                                                  instance_count: 2,
+                                                                 scope: 'Availability Zone',
                                                                  class: "Aws::EC2::Types::ReservedInstances")
         reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [reserved_ec2_instance1, reserved_ec2_instance2])
         ec2_client = double('ec2_client', describe_reserved_instances: reserved_ec2_instances)
@@ -134,6 +136,7 @@ module SportNginAwsAuditor
                                                                            state: "retired",
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 4,
+                                                                           scope: 'Availability Zone',
                                                                            class: "Aws::EC2::Types::ReservedInstances",
                                                                            end: @time - 86400)
           retired_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
@@ -142,6 +145,7 @@ module SportNginAwsAuditor
                                                                            state: "retired",
                                                                            availability_zone: "us-east-1b",
                                                                            instance_count: 2,
+                                                                           scope: 'Availability Zone',
                                                                            class: "Aws::EC2::Types::ReservedInstances",
                                                                            end: @time - 86400)
           reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
@@ -150,6 +154,7 @@ module SportNginAwsAuditor
                                                                    state: "active",
                                                                    availability_zone: "us-east-1b",
                                                                    instance_count: 2,
+                                                                   scope: 'Availability Zone',
                                                                    class: "Aws::EC2::Types::ReservedInstances")
           reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [retired_reserved_ec2_instance1,
                                                                                          retired_reserved_ec2_instance2,

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -1,0 +1,167 @@
+require "sport_ngin_aws_auditor"
+
+module SportNginAwsAuditor
+  describe InstanceHelper do
+    before :each do
+      @ec2_instance1 = double('ec2_instance', instance_id: "i-thisisfake",
+                                               instance_type: "t2.small",
+                                               vpc_id: "vpc-alsofake",
+                                               platform: "Linux VPC",
+                                               state: nil,
+                                               placement: nil,
+                                               tags: nil,
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-01',
+                                               availability_zone: 'us-east-1b')
+      @ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
+                                               instance_type: "t2.medium",
+                                               vpc_id: "vpc-alsofake",
+                                               platform: "Windows",
+                                               state: nil,
+                                               placement: nil,
+                                               tags: nil,
+                                               class: "Aws::EC2::Types::Instance",
+                                               key_name: 'Example-instance-02',
+                                               availability_zone: 'us-east-1b')
+      @reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
+                                                                instance_type: "t2.small",
+                                                                product_description: "Linux/UNIX (Amazon VPC)",
+                                                                state: "active",
+                                                                availability_zone: "us-east-1b",
+                                                                instance_count: 2,
+                                                                scope: 'Availability Zone',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
+                                                                instance_type: "t2.medium",
+                                                                product_description: "Windows",
+                                                                state: "active",
+                                                                availability_zone: "us-east-1b",
+                                                                instance_count: 4,
+                                                                scope: 'Availability Zone',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @region_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
+                                                                instance_type: "t2.small",
+                                                                product_description: "Linux/UNIX (Amazon VPC)",
+                                                                state: "active",
+                                                                availability_zone: nil,
+                                                                instance_count: 2,
+                                                                scope: 'Region',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @region_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
+                                                                instance_type: "t2.medium",
+                                                                product_description: "Windows",
+                                                                state: "active",
+                                                                availability_zone: nil,
+                                                                instance_count: 4,
+                                                                scope: 'Region',
+                                                                class: "Aws::EC2::Types::ReservedInstances")
+      @ec2_instances = [@ec2_instance1, @ec2_instance2]
+      @reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1]
+      @region_reserved_instances = [@region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
+      @all_reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1, @region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_instances).and_return(@ec2_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@all_reserved_instances)
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
+      allow(@ec2_instance1).to receive(:count).and_return(1)
+      allow(@ec2_instance2).to receive(:count).and_return(1)
+      allow(@ec2_instance1).to receive(:to_s).and_return('Linux VPC us-east-1b t2.small')
+      allow(@ec2_instance2).to receive(:to_s).and_return('Windows us-east-1b t2.medium')
+      allow(@ec2_instance1).to receive(:name).and_return(@ec2_instance1.key_name)
+      allow(@ec2_instance2).to receive(:name).and_return(@ec2_instance2.key_name)
+      allow(@ec2_instance1).to receive(:tag_reason).and_return(nil)
+      allow(@ec2_instance2).to receive(:tag_reason).and_return(nil)
+      allow(@ec2_instance1).to receive(:tag_value).and_return(nil)
+      allow(@ec2_instance2).to receive(:tag_value).and_return(nil)
+      allow(@reserved_ec2_instance1).to receive(:count).and_return(2)
+      allow(@reserved_ec2_instance2).to receive(:count).and_return(2)
+      allow(@reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC us-east-1b t2.small')
+      allow(@reserved_ec2_instance2).to receive(:to_s).and_return('Windows us-east-1b t2.medium')
+      allow(@region_reserved_ec2_instance1).to receive(:platform).and_return('Linux VPC')
+      allow(@region_reserved_ec2_instance1).to receive(:instance_type).and_return('t2.small')
+      allow(@region_reserved_ec2_instance1).to receive(:count).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:platform).and_return('Windows')
+      allow(@region_reserved_ec2_instance2).to receive(:instance_type).and_return('t2.medium')
+      allow(@region_reserved_ec2_instance2).to receive(:count).and_return(4)
+      allow(@region_reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC  t2.small')
+      allow(@region_reserved_ec2_instance2).to receive(:to_s).and_return('Windows  t2.medium')
+    end
+
+    context '#instance_count_hash' do
+      it 'should add the instances to the hash of differences' do
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.instance_count_hash(@ec2_instances)
+        expect(result).to eq({'Linux VPC us-east-1b t2.small' => {count: 1, region_based: false}, 'Windows us-east-1b t2.medium' => {count: 1, region_based: false}})
+      end
+    end
+
+    context '#apply_tagged_instances' do
+      it 'should add the instances to the hash of differences' do
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.apply_tagged_instances(@ec2_instances, {})
+        expect(result).to eq({'Linux VPC us-east-1b t2.small with tag' => {count: 1, name: @ec2_instance1.key_name, tag_reason: nil, tag_value: nil, region_based: false},
+                              'Windows us-east-1b t2.medium with tag' => {count: 1, name: @ec2_instance2.key_name, tag_reason: nil, tag_value: nil, region_based: false}})
+      end
+    end
+
+    context '#apply_region_ris' do
+      it 'should factor in the region based RIs into the counting when there is a mixture of region based and non region based' do
+        klass = SportNginAwsAuditor::EC2Instance
+        allow(@ec2_instance1).to receive(:count).and_return(5)
+        allow(@ec2_instance2).to receive(:count).and_return(5)
+        allow(@region_reserved_ec2_instance1).to receive(:count=)
+        allow(@region_reserved_ec2_instance2).to receive(:count=)
+        instance_hash = klass.instance_count_hash(@ec2_instances)
+        ris = klass.instance_count_hash(@reserved_instances)
+        differences = Hash.new()
+        instance_hash.keys.concat(ris.keys).uniq.each do |key|
+          instance_count = instance_hash.has_key?(key) ? instance_hash[key][:count] : 0
+          ris_count = ris.has_key?(key) ? ris[key][:count] : 0
+          differences[key] = {count: ris_count - instance_count, region_based: false}
+        end
+        result = klass.apply_region_ris(@region_reserved_instances, differences)
+        expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 0, region_based: false},
+                                   "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
+      end
+
+      it 'should factor in the region based RIs into the counting when there are no zone specific RIs' do
+        klass = SportNginAwsAuditor::EC2Instance
+        allow(@ec2_instance1).to receive(:count).and_return(-2)
+        allow(@ec2_instance2).to receive(:count).and_return(5)
+        allow(@region_reserved_ec2_instance1).to receive(:count=)
+        allow(@region_reserved_ec2_instance2).to receive(:count=)
+        instance_hash = klass.instance_count_hash(@ec2_instances)
+        result = klass.apply_region_ris(@region_reserved_instances, instance_hash)
+        expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 5, region_based: false},
+                                     "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
+      end
+    end
+
+    context '#filter_ris_region_based' do
+      it 'should filter all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.filter_ris_region_based(@all_reserved_instances)
+        expect(result).to eq(@region_reserved_instances)
+      end
+    end
+
+    context '#filter_ris_availability_zone' do
+      it 'should remove all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.filter_ris_availability_zone(@all_reserved_instances)
+        expect(result).to eq(@reserved_instances)
+      end
+    end
+
+    context '#gather_instance_tag_date' do
+      it 'should remove all of the region based RIs out of the entire RI list' do
+        klass = SportNginAwsAuditor::EC2Instance
+        allow(@ec2_instance1).to receive(:no_reserved_instance_tag_value).and_return('08/29/1995')
+        result = klass.gather_instance_tag_date(@ec2_instance1)
+        date_hash = Date._strptime('08/29/1995', '%m/%d/%Y')
+        value = Date.new(date_hash[:year], date_hash[:mon], date_hash[:mday]) if date_hash
+        expect(result).to eq(value)
+      end
+    end
+
+  end
+end

--- a/spec/sport_ngin_aws_auditor/instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_spec.rb
@@ -3,17 +3,17 @@ require "sport_ngin_aws_auditor"
 module SportNginAwsAuditor
   describe Instance do
     it "should make a reserved instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", [4])
+      instance = Instance.new("Windows VPC  m1.large", {count: 4, region_based: true}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("reserved")
-      expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
+      expect(instance.type).to eq("Windows VPC us-east m1.large")
       expect(instance.count).to eq(4)
       expect(instance.tagged?).to eq(false)
       expect(instance.reserved?).to eq(true)
     end
 
     it "should make a running instance with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large", [-1])
+      instance = Instance.new("Windows VPC us-east-1e m1.large", {count: -1, region_based: false}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("running")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")
@@ -21,7 +21,7 @@ module SportNginAwsAuditor
     end
 
     it "should make an instance with a tag with proper attributes" do
-      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", [4, 'example-instance-name', 'This is an example', '09/12/2015'])
+      instance = Instance.new("Windows VPC us-east-1e m1.large with tag", {count: 4, name: 'example-instance-name', tag_reason: 'This is an example', tag_value: '09/12/2015', region_based: false}, 'us-east')
       expect(instance).to be_an_instance_of(Instance)
       expect(instance.category).to eq("tagged")
       expect(instance.type).to eq("Windows VPC us-east-1e m1.large")


### PR DESCRIPTION
Description and Impact
----------------------
There should only be one tagged output per line, even if the description of the instance is the same. The printed tagged outputs should include the name of the instance and the description, instead of just the description. The list of Unused RIs should take tagged outputs into account, so show that an RI is covering a tagged output. The list of recently expired tags should output tags that expire today.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Run command to print data in terminal: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]`
- [ ] Run command to print data into Slack: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]`
- [ ] Verify that numbers are counting correctly for the Unused RI lists compared to previous printouts
- [ ] Verify that there is one tagged instance on each output