### PR TITLE
Fixing bugs with outputs and counts

### DIFF
--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -28,18 +28,28 @@ module SportNginAwsAuditor
     def add_instances_with_tag_to_hash(instances_to_add, instance_hash)
       instances_to_add.each do |instance|
         next if instance.nil?
-        key = instance.to_s << " with tag"
+        key = instance.to_s.dup << " with tag (" << instance.name << ")"
         instance_result = []
-        if instance_hash.has_key?(key)
-          instance_result << instance_hash[key][0] + instance.count
+        
+        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][0] > 0
+          current_val = instance_hash[instance.to_s][0]
+          val = current_val - instance.count
+          new_val = val >= 0 ? val : 0
+          instance_hash[instance.to_s][0] = new_val
+
+          val = instance.count - current_val
+          new_val = val >= 0 ? val : 0
+          instance_result << new_val
         else
           instance_result << instance.count
         end
+
         instance_result << instance.name
         instance_result << instance.tag_reason
         instance_result << instance.tag_value
         instance_hash[key] = instance_result
       end if instances_to_add
+
       instance_hash
     end
 
@@ -91,7 +101,7 @@ module SportNginAwsAuditor
       instances.select do |instance|
         value = gather_instance_tag_date(instance)
         one_week_ago = (Date.today - 7).to_s
-        if (value && (one_week_ago < value.to_s) && (value.to_s < Date.today.to_s))
+        if (value && (one_week_ago < value.to_s) && (value.to_s <= Date.today.to_s))
           return_array << RecentlyRetiredTag.new(value.to_s, instance.to_s, instance.name, instance.tag_reason)
         end
       end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -84,9 +84,9 @@ module SportNginAwsAuditor
         color, rgb, prefix = color_chooser(instance)
         if instance.tagged?
           if instance.reason
-            puts "#{prefix} #{name}: #{count} (expiring on #{instance.tag_value} because of #{instance.reason})".blue
+            puts "#{prefix} #{name}: (expiring on #{instance.tag_value} because of #{instance.reason})".blue
           else
-            say "<%= color('#{prefix} #{name}: #{count} (expiring on #{instance.tag_value})', :#{color}) %>"
+            say "<%= color('#{prefix} #{name}: (expiring on #{instance.tag_value})', :#{color}) %>"
           end
         else
           say "<%= color('#{prefix} #{name}: #{count}', :#{color}) %>"
@@ -152,9 +152,9 @@ module SportNginAwsAuditor
           color, rgb, prefix = color_chooser(tagged)
           
           if tagged.reason
-            text = "#{prefix} #{type}: #{count} (expiring on #{tagged.tag_value} because of #{tagged.reason})"
+            text = "#{prefix} #{type}: (expiring on #{tagged.tag_value} because of #{tagged.reason})"
           else
-            text = "#{prefix} #{type}: #{count} (expiring on #{tagged.tag_value})"
+            text = "#{prefix} #{type}: (expiring on #{tagged.tag_value})"
           end
 
           slack_instances.attachments.push({"color" => rgb, "text" => text, "mrkdwn_in" => ["text"]})


### PR DESCRIPTION
Description and Impact
----------------------
There should only be one tagged output per line, even if the description of the instance is the same. The printed tagged outputs should include the name of the instance and the description, instead of just the description. The list of Unused RIs should take tagged outputs into account, so show that an RI is covering a tagged output. The list of recently expired tags should output tags that expire today.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Run command to print data in terminal: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]`
- [ ] Run command to print data into Slack: `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]`
- [ ] Verify that numbers are counting correctly for the Unused RI lists compared to previous printouts (AKA RIs should be showing as counting tagged instances)
- [ ] Verify that there is one tagged instance on each output, and the entire name of the tagged instance is included in the printout