### PR TITLE
Add the ability to pass config data in as a flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ branches:
 
 language: ruby
 rvm:
-  - 2.2.0
+  - 2.2.2
+  - 2.2.3
+  - 2.2.4
   - 2.2.5
 cache: bundler
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1
-  - 2.2
+  - 2.2.5
 cache: bundler
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ branches:
 
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1
+  - 2.2.0
   - 2.2.5
 cache: bundler
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ branches:
 
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.2.3
-  - 2.2.4
-  - 2.2.5
+  - 2.2
 cache: bundler
 script: bundle exec rspec

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -7,7 +7,7 @@ command 'audit' do |c|
   c.switch [:r, :reserved], :desc => "Shows reserved instance counts"
   c.switch [:i, :instances], :desc => "Shows current instance counts"
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
-  c.flag [:h, :config_hash], :default_value => nil, :desc => "Print the audit according to this config hash instead of to config file"
+  c.flag [:h, :config_json], :default_value => nil, :desc => "Print the audit according to this config json object instead of to config file"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.action do |global_options, options, args|

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -7,7 +7,7 @@ command 'audit' do |c|
   c.switch [:r, :reserved], :desc => "Shows reserved instance counts"
   c.switch [:i, :instances], :desc => "Shows current instance counts"
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
-  c.flag [:h, :channel], :default_value => nil, :desc => "Print the audit to this channel instead of one in config file"
+  c.flag [:h, :config_hash], :default_value => nil, :desc => "Print the audit according to this hash instead of to config file"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.action do |global_options, options, args|

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -7,6 +7,7 @@ command 'audit' do |c|
   c.switch [:r, :reserved], :desc => "Shows reserved instance counts"
   c.switch [:i, :instances], :desc => "Shows current instance counts"
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
+  c.flag [:h, :channel], :default_value => nil, :desc => "Print the audit to this channel instead of one in config file"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.action do |global_options, options, args|

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -7,7 +7,7 @@ command 'audit' do |c|
   c.switch [:r, :reserved], :desc => "Shows reserved instance counts"
   c.switch [:i, :instances], :desc => "Shows current instance counts"
   c.flag [:t, :tag], :default_value => "no-reserved-instance", :desc => "Read a tag and group separately during audit"
-  c.flag [:h, :config_hash], :default_value => nil, :desc => "Print the audit according to this hash instead of to config file"
+  c.flag [:h, :config_hash], :default_value => nil, :desc => "Print the audit according to this config hash instead of to config file"
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.action do |global_options, options, args|

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -4,16 +4,22 @@ module SportNginAwsAuditor
   class NotifySlack
     attr_accessor :text, :channel, :webhook, :username, :icon_url, :icon_emoji, :attachments
 
-    def initialize(text, channel)
+    def initialize(text, config_hash)
       self.text = text
       self.attachments = []
       if SportNginAwsAuditor::Config.slack
-        self.channel = channel || SportNginAwsAuditor::Config.slack[:channel]
+        self.channel = SportNginAwsAuditor::Config.slack[:channel]
         self.username = SportNginAwsAuditor::Config.slack[:username]
         self.webhook = SportNginAwsAuditor::Config.slack[:webhook]
         self.icon_url = SportNginAwsAuditor::Config.slack[:icon_url]
+      elsif config_hash
+        hs = eval(config_hash)
+        self.channel = hs[:slack][:channel]
+        self.username = hs[:slack][:username]
+        self.webhook = hs[:slack][:webhook]
+        self.icon_url = hs[:slack][:icon_url]
       else
-        puts "To use Slack, you must provide a separate config file. See the README for more information."
+        puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end
     end
 
@@ -31,3 +37,5 @@ module SportNginAwsAuditor
     end
   end
 end
+
+# GLI_DEBUG=true bin/sport-ngin-aws-auditor audit --config_hash='{:slack_token =>["S5msluvHPL9Y7k558yFgFvF8"],:slack=>{:username=>"AWS Auditor",:icon_url=>"http://i.imgur.com/86x8PSg.jpg",:channel=>"#ops-firehose",:webhook=>"https://hooks.slack.com/services/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"}}' -s staging

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -16,13 +16,9 @@ module SportNginAwsAuditor
       elsif config_hash
         hs = eval(config_hash)
         self.channel = hs[:slack][:channel]
-        puts "self.channel: #{self.channel}"
         self.username = hs[:slack][:username]
-        puts "self.username: #{self.username}"
         self.webhook = hs[:slack][:webhook]
-        puts "self.webhook: #{self.webhook}"
         self.icon_url = hs[:slack][:icon_url]
-        puts "self.icon_url: #{self.icon_url}"
       else
         puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end
@@ -37,6 +33,7 @@ module SportNginAwsAuditor
                    icon_url: icon_url,
                    attachments: attachments
                   }
+        puts "I'm posting to Slack!!"
         HTTParty.post(options[:webhook], :body => "payload=#{options.to_json}")
       end
     end

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -4,11 +4,11 @@ module SportNginAwsAuditor
   class NotifySlack
     attr_accessor :text, :channel, :webhook, :username, :icon_url, :icon_emoji, :attachments
 
-    def initialize(text)
+    def initialize(text, channel)
       self.text = text
       self.attachments = []
       if SportNginAwsAuditor::Config.slack
-        self.channel = SportNginAwsAuditor::Config.slack[:channel]
+        self.channel = channel || SportNginAwsAuditor::Config.slack[:channel]
         self.username = SportNginAwsAuditor::Config.slack[:username]
         self.webhook = SportNginAwsAuditor::Config.slack[:webhook]
         self.icon_url = SportNginAwsAuditor::Config.slack[:icon_url]

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -7,8 +7,6 @@ module SportNginAwsAuditor
     def initialize(text, config_hash)
       self.text = text
       self.attachments = []
-      puts "Config_Hash: #{config_hash}"
-      puts "congig hash type: #{config_hash.class}"
 
       if SportNginAwsAuditor::Config.slack
         self.channel = SportNginAwsAuditor::Config.slack[:channel]
@@ -18,9 +16,13 @@ module SportNginAwsAuditor
       elsif config_hash
         hs = eval(config_hash)
         self.channel = hs[:slack][:channel]
+        puts "self.channel: #{self.channel}"
         self.username = hs[:slack][:username]
+        puts "self.username: #{self.username}"
         self.webhook = hs[:slack][:webhook]
+        puts "self.webhook: #{self.webhook}"
         self.icon_url = hs[:slack][:icon_url]
+        puts "self.icon_url: #{self.icon_url}"
       else
         puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -4,21 +4,21 @@ module SportNginAwsAuditor
   class NotifySlack
     attr_accessor :text, :channel, :webhook, :username, :icon_url, :icon_emoji, :attachments, :config_hash
 
-    def initialize(text, config_hash)
+    def initialize(text, config)
       self.text = text
       self.attachments = []
-      self.config_hash = eval(config_hash) if config_hash
+      self.config_hash = eval(config) if config
 
       if SportNginAwsAuditor::Config.slack
         self.channel = SportNginAwsAuditor::Config.slack[:channel]
         self.username = SportNginAwsAuditor::Config.slack[:username]
         self.webhook = SportNginAwsAuditor::Config.slack[:webhook]
         self.icon_url = SportNginAwsAuditor::Config.slack[:icon_url]
-      elsif config_hash
-        self.channel = config_hash[:slack][:channel]
-        self.username = config_hash[:slack][:username]
-        self.webhook = config_hash[:slack][:webhook]
-        self.icon_url = config_hash[:slack][:icon_url]
+      elsif self.config_hash
+        self.channel = self.config_hash[:slack][:channel]
+        self.username = self.config_hash[:slack][:username]
+        self.webhook = self.config_hash[:slack][:webhook]
+        self.icon_url = self.config_hash[:slack][:icon_url]
       else
         puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -7,8 +7,9 @@ module SportNginAwsAuditor
     def initialize(text, config_params)
       self.text = text
       self.attachments = []
-      config_file = SportNginAwsAuditor::Config.slack || {}
-      self.config = config_params ? config_file.merge(eval(config_params)) : config_file
+      self.config = SportNginAwsAuditor::Config.slack.merge(eval(config_params)) if config_params
+      # config_file = SportNginAwsAuditor::Config.slack || {}
+      # self.config = config_params ? config_file.merge(eval(config_params)) : config_file
 
       if self.config
         self.channel = self.config[:channel]

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -41,4 +41,6 @@ module SportNginAwsAuditor
   end
 end
 
-# GLI_DEBUG=true bin/sport-ngin-aws-auditor audit --config_hash='{:slack_token =>["S5msluvHPL9Y7k558yFgFvF8"],:slack=>{:username=>"AWS Auditor",:icon_url=>"http://i.imgur.com/86x8PSg.jpg",:channel=>"#ops-firehose",:webhook=>"https://hooks.slack.com/services/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"}}' -s staging
+# GLI_DEBUG=true bin/sport-ngin-aws-auditor audit --config_hash="{:slack_token=>{\"token\"=>\"S5msluvHPL9Y7k558yFgFvF8\"}, :slack=>{:username=>\"AWS Auditor\", :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\", :channel=>\"#test-webhook-channel\", :webhook=>\"https://hooks.slack.com/services/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\"}}" -s staging
+
+

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -2,30 +2,26 @@ require 'httparty'
 
 module SportNginAwsAuditor
   class NotifySlack
-    attr_accessor :text, :channel, :webhook, :username, :icon_url, :icon_emoji, :attachments, :config_hash
+    attr_accessor :text, :channel, :webhook, :username, :icon_url, :icon_emoji, :attachments, :config
 
-    def initialize(text, config)
+    def initialize(text, config_params)
       self.text = text
       self.attachments = []
-      self.config_hash = eval(config) if config
+      config_file = SportNginAwsAuditor::Config.slack || {}
+      self.config = config_params ? config_file.merge(eval(config_params)) : config_file
 
-      if SportNginAwsAuditor::Config.slack
-        self.channel = SportNginAwsAuditor::Config.slack[:channel]
-        self.username = SportNginAwsAuditor::Config.slack[:username]
-        self.webhook = SportNginAwsAuditor::Config.slack[:webhook]
-        self.icon_url = SportNginAwsAuditor::Config.slack[:icon_url]
-      elsif self.config_hash
-        self.channel = self.config_hash[:slack][:channel]
-        self.username = self.config_hash[:slack][:username]
-        self.webhook = self.config_hash[:slack][:webhook]
-        self.icon_url = self.config_hash[:slack][:icon_url]
+      if self.config
+        self.channel = self.config[:channel]
+        self.username = self.config[:username]
+        self.webhook = self.config[:webhook]
+        self.icon_url = self.config[:icon_url]
       else
         puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end
     end
 
     def perform
-      if SportNginAwsAuditor::Config.slack || config_hash
+      if config
         options = {text: text,
                    webhook: webhook,
                    channel: channel,

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -7,9 +7,8 @@ module SportNginAwsAuditor
     def initialize(text, config_params)
       self.text = text
       self.attachments = []
-      self.config = SportNginAwsAuditor::Config.slack.merge(eval(config_params)) if config_params
-      # config_file = SportNginAwsAuditor::Config.slack || {}
-      # self.config = config_params ? config_file.merge(eval(config_params)) : config_file
+      config_file = SportNginAwsAuditor::Config.slack || {}
+      self.config = config_params ? config_file.merge(JSON.parse(config_params)).symbolize_keys : config_file
 
       if self.config
         self.channel = self.config[:channel]

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'json'
 
 module SportNginAwsAuditor
   class NotifySlack

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -8,14 +8,14 @@ module SportNginAwsAuditor
     def initialize(text, config_params)
       self.text = text
       self.attachments = []
-      config_file = SportNginAwsAuditor::Config.slack || {}
-      self.config = config_params ? config_file.merge(JSON.parse(config_params)).symbolize_keys : config_file
-
+      config_file = SportNginAwsAuditor::Config.slack.to_h || {}
+      self.config = config_params ? config_file.merge(JSON.parse(config_params)) : config_file
+      
       if self.config
-        self.channel = self.config[:channel]
-        self.username = self.config[:username]
-        self.webhook = self.config[:webhook]
-        self.icon_url = self.config[:icon_url]
+        self.channel = self.config['channel']
+        self.username = self.config['username']
+        self.webhook = self.config['webhook']
+        self.icon_url = self.config['icon_url']
       else
         puts "To use Slack, you must provide either a separate config file or a hash of config data. See the README for more information."
       end

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -38,7 +38,3 @@ module SportNginAwsAuditor
     end
   end
 end
-
-# GLI_DEBUG=true bin/sport-ngin-aws-auditor audit --config_hash="{:slack_token=>{\"token\"=>\"S5msluvHPL9Y7k558yFgFvF8\"}, :slack=>{:username=>\"AWS Auditor\", :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\", :channel=>\"#test-webhook-channel\", :webhook=>\"https://hooks.slack.com/services/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\"}}" -s staging
-
-

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -7,6 +7,8 @@ module SportNginAwsAuditor
     def initialize(text, config_hash)
       self.text = text
       self.attachments = []
+      puts "Config_Hash: #{config_hash}"
+      puts "congig hash type: #{config_hash.class}"
 
       if SportNginAwsAuditor::Config.slack
         self.channel = SportNginAwsAuditor::Config.slack[:channel]

--- a/lib/sport_ngin_aws_auditor/notify_slack.rb
+++ b/lib/sport_ngin_aws_auditor/notify_slack.rb
@@ -7,6 +7,7 @@ module SportNginAwsAuditor
     def initialize(text, config_hash)
       self.text = text
       self.attachments = []
+
       if SportNginAwsAuditor::Config.slack
         self.channel = SportNginAwsAuditor::Config.slack[:channel]
         self.username = SportNginAwsAuditor::Config.slack[:username]

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -29,8 +29,6 @@ module SportNginAwsAuditor
                  ["RDSInstance", options[:rds]],
                  ["CacheInstance", options[:cache]]]
 
-        puts "!*!*!*!*!*!*!*!*!*!*!*!*!*!*!!*!*!*!*"
-
         if !slack
           print "Gathering info, please wait..."; print "\r"
         else

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -16,6 +16,7 @@ module SportNginAwsAuditor
       def self.execute(environment, options=nil, global_options=nil)
         aws(environment, global_options[:aws_roles])
         @options = options
+        puts "!!!! #{options[:config_hash]}"
         slack = options[:slack]
         no_selection = !(options[:ec2] || options[:rds] || options[:cache])
 

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -126,7 +126,7 @@ module SportNginAwsAuditor
 
       def self.print_discrepancies(discrepancy_array, audit_results, class_type, environment)
         title = "Some #{class_type} discrepancies for #{environment} exist:\n"
-        slack_instances = NotifySlack.new(title, options[:channel])
+        slack_instances = NotifySlack.new(title, options[:config_hash])
 
         discrepancy_array.each do |discrepancy|
           type = discrepancy.type
@@ -144,7 +144,7 @@ module SportNginAwsAuditor
 
       def self.print_tagged(tagged_array, audit_results, class_type, environment)
         title = "There are currently some tagged #{class_type}s in #{environment}:\n"
-        slack_instances = NotifySlack.new(title, options[:channel])
+        slack_instances = NotifySlack.new(title, options[:config_hash])
 
         tagged_array.each do |tagged|
           type = tagged.type
@@ -173,7 +173,7 @@ module SportNginAwsAuditor
           message << "*#{name}* (#{count}) on *#{expiration_date}*\n"
         end
           
-        slack_retired_ris = NotifySlack.new(message, options[:channel])
+        slack_retired_ris = NotifySlack.new(message, options[:config_hash])
         slack_retired_ris.perform
       end
 
@@ -188,7 +188,7 @@ module SportNginAwsAuditor
           end
         end
 
-        slack_retired_tags = NotifySlack.new(message, options[:channel])
+        slack_retired_tags = NotifySlack.new(message, options[:config_hash])
         slack_retired_tags.perform
       end
 

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -126,7 +126,7 @@ module SportNginAwsAuditor
 
       def self.print_discrepancies(discrepancy_array, audit_results, class_type, environment)
         title = "Some #{class_type} discrepancies for #{environment} exist:\n"
-        slack_instances = NotifySlack.new(title, options[:config_hash])
+        slack_instances = NotifySlack.new(title, options[:config_json])
 
         discrepancy_array.each do |discrepancy|
           type = discrepancy.type
@@ -144,7 +144,7 @@ module SportNginAwsAuditor
 
       def self.print_tagged(tagged_array, audit_results, class_type, environment)
         title = "There are currently some tagged #{class_type}s in #{environment}:\n"
-        slack_instances = NotifySlack.new(title, options[:config_hash])
+        slack_instances = NotifySlack.new(title, options[:config_json])
 
         tagged_array.each do |tagged|
           type = tagged.type
@@ -173,7 +173,7 @@ module SportNginAwsAuditor
           message << "*#{name}* (#{count}) on *#{expiration_date}*\n"
         end
           
-        slack_retired_ris = NotifySlack.new(message, options[:config_hash])
+        slack_retired_ris = NotifySlack.new(message, options[:config_json])
         slack_retired_ris.perform
       end
 
@@ -188,7 +188,7 @@ module SportNginAwsAuditor
           end
         end
 
-        slack_retired_tags = NotifySlack.new(message, options[:config_hash])
+        slack_retired_tags = NotifySlack.new(message, options[:config_json])
         slack_retired_tags.perform
       end
 

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -126,7 +126,7 @@ module SportNginAwsAuditor
 
       def self.print_discrepancies(discrepancy_array, audit_results, class_type, environment)
         title = "Some #{class_type} discrepancies for #{environment} exist:\n"
-        slack_instances = NotifySlack.new(title)
+        slack_instances = NotifySlack.new(title, options[:channel])
 
         discrepancy_array.each do |discrepancy|
           type = discrepancy.type
@@ -144,7 +144,7 @@ module SportNginAwsAuditor
 
       def self.print_tagged(tagged_array, audit_results, class_type, environment)
         title = "There are currently some tagged #{class_type}s in #{environment}:\n"
-        slack_instances = NotifySlack.new(title)
+        slack_instances = NotifySlack.new(title, options[:channel])
 
         tagged_array.each do |tagged|
           type = tagged.type
@@ -173,7 +173,7 @@ module SportNginAwsAuditor
           message << "*#{name}* (#{count}) on *#{expiration_date}*\n"
         end
           
-        slack_retired_ris = NotifySlack.new(message)
+        slack_retired_ris = NotifySlack.new(message, options[:channel])
         slack_retired_ris.perform
       end
 
@@ -188,7 +188,7 @@ module SportNginAwsAuditor
           end
         end
 
-        slack_retired_tags = NotifySlack.new(message)
+        slack_retired_tags = NotifySlack.new(message, options[:channel])
         slack_retired_tags.perform
       end
 

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -16,7 +16,6 @@ module SportNginAwsAuditor
       def self.execute(environment, options=nil, global_options=nil)
         aws(environment, global_options[:aws_roles])
         @options = options
-        puts "!!!! #{options[:config_hash]}"
         slack = options[:slack]
         no_selection = !(options[:ec2] || options[:rds] || options[:cache])
 
@@ -29,6 +28,8 @@ module SportNginAwsAuditor
         cycle = [["EC2Instance", options[:ec2]],
                  ["RDSInstance", options[:rds]],
                  ["CacheInstance", options[:cache]]]
+
+        puts "!*!*!*!*!*!*!*!*!*!*!*!*!*!*!!*!*!*!*"
 
         if !slack
           print "Gathering info, please wait..."; print "\r"

--- a/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
+++ b/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
@@ -1,4 +1,5 @@
 require "sport_ngin_aws_auditor"
+require 'json'
 
 module SportNginAwsAuditor
   describe NotifySlack do
@@ -31,13 +32,11 @@ module SportNginAwsAuditor
 
     it 'should ping Slack Notifier even when passing in config as a hash' do
       notifier = double('notifier')
-      config_hash = "{:slack=>{:username=>\"AWS Auditor\",
-                               :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\",
-                               :channel=>\"#test-webhook-channel\",
-                               :webhook=>\"https://hooks.slack.com/services/thisisafake\"
-                             }
-                    }"
-      config_file = nil
+      config_hash = {:username=>"AWS Auditor",
+                     :icon_url=>"http://i.imgur.com/86x8PSg.jpg",
+                     :channel=>"#test-webhook-channel",
+                     :webhook=>"https://hooks.slack.com/services/thisisafake"
+                    }.to_json
       expect(HTTParty).to receive(:post)
       message = NotifySlack.new("Test message", config_hash)
       message.perform

--- a/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
+++ b/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
@@ -16,17 +16,31 @@ module SportNginAwsAuditor
     it 'should ping Slack Notifier' do
       notifier = double('notifier')
       expect(HTTParty).to receive(:post)
-      message = NotifySlack.new("Test message")
+      message = NotifySlack.new("Test message", nil)
       message.perform
     end
 
      it 'should define certain values' do
-      message = NotifySlack.new("Test message")
+      message = NotifySlack.new("Test message", nil)
       expect(message.text).to eq("Test message")
       expect(message.channel).to eq("#random-test-channel")
       expect(message.username).to eq("Random User")
       expect(message.webhook).to eq("https://hooks.slack.com/services/totallyrandom/fakewebhookurl")
       expect(message.icon_url).to eq("http://random-picture.jpg")
+    end
+
+    it 'should ping Slack Notifier even when passing in config as a hash' do
+      notifier = double('notifier')
+      config_hash = "{:slack=>{:username=>\"AWS Auditor\",
+                               :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\",
+                               :channel=>\"#test-webhook-channel\",
+                               :webhook=>\"https://hooks.slack.com/services/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\"
+                             }
+                    }"
+      config_file = nil
+      expect(HTTParty).to receive(:post)
+      message = NotifySlack.new("Test message", config_hash)
+      message.perform
     end
   end
 end

--- a/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
+++ b/spec/sport_ngin_aws_auditor/notify_slack_spec.rb
@@ -34,7 +34,7 @@ module SportNginAwsAuditor
       config_hash = "{:slack=>{:username=>\"AWS Auditor\",
                                :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\",
                                :channel=>\"#test-webhook-channel\",
-                               :webhook=>\"https://hooks.slack.com/services/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\"
+                               :webhook=>\"https://hooks.slack.com/services/thisisafake\"
                              }
                     }"
       config_file = nil

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'highline', '~> 1.6'
   spec.add_dependency 'google_drive', '~> 1.0.0.pre2'
   spec.add_dependency 'google-api-client', '~> 0.8.6'
-  spec.add_dependency 'rack', '~> 1.3.0'
+  spec.add_dependency 'rack', '>= 1.3.0'
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'httparty'
   spec.add_dependency 'colorize'

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google_drive', '~> 1.0.0.pre2'
   spec.add_dependency 'google-api-client', '~> 0.8.6'
   spec.add_dependency 'rack', '~> 1.3.0'
-  spec.add_dependency 'activesupport', '~> 3.2'
+  spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'httparty'
   spec.add_dependency 'colorize'
 


### PR DESCRIPTION
Description and Impact
----------------------
Give the option for passing config information in as a flag, instead of as a file.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit --config_hash="{:slack=>{:username=>\"AWS Auditor\", :icon_url=>\"http://i.imgur.com/86x8PSg.jpg\", :channel=>\"#[slack channel]\", :webhook=>\"[a valid webhook url]"}}" -s [account]` and see this work!
- [ ] `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` to just make sure it works when using a config file