### PR TITLE
Caching should not affect RI counts between runs

### DIFF
--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date, :mutable_count_remaining
+    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date, :count_remaining
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date, :mutable_count
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
       private :get_more_info
     end
 
-    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date, :mutable_count
+    attr_accessor :id, :name, :platform, :availability_zone, :scope, :instance_type, :count, :stack_name, :tag_value, :tag_reason, :expiration_date, :mutable_count_remaining
     def initialize(ec2_instance, tag_name, count=1)
       if ec2_instance.class.to_s == "Aws::EC2::Types::ReservedInstances"
         self.id = ec2_instance.reserved_instances_id

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -55,7 +55,7 @@ module SportNginAwsAuditor
 
     def apply_region_ris(ris_region, differences)
       ris_region.each do |ri|
-        ri.mutable_count = ri.count
+        ri.mutable_count_remaining = ri.count
 
         differences.each do |key, value|
           # if key = 'Linux VPC us-east-1a t2.medium'...
@@ -70,17 +70,17 @@ module SportNginAwsAuditor
           size[0] = ''
 
           if (platform == ri.platform) && (size == ri.instance_type) && (value[:count] < 0)
-            until (ri.mutable_count == 0) || (value[:count] == 0)
+            until (ri.mutable_count_remaining == 0) || (value[:count] == 0)
               value[:count] = value[:count] + 1
-              ri.mutable_count = ri.mutable_count - 1
+              ri.mutable_count_remaining = ri.mutable_count_remaining - 1
             end
           end
         end
       end
 
       ris_region.each do |ri|
-        differences[ri.to_s] = {:count => ri.mutable_count, :region_based => true}
-        ri.mutable_count = nil
+        differences[ri.to_s] = {:count => ri.mutable_count_remaining, :region_based => true}
+        ri.mutable_count_remaining = nil
       end
     end
 

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -55,6 +55,8 @@ module SportNginAwsAuditor
 
     def apply_region_ris(ris_region, differences)
       ris_region.each do |ri|
+        ri.mutable_count = ri.count
+
         differences.each do |key, value|
           # if key = 'Linux VPC us-east-1a t2.medium'...
           my_match = key.match(/(\w*\s*\w*\s*)\w{2}-\w{2,}-\w{2}(\s*\S*)/)
@@ -68,16 +70,17 @@ module SportNginAwsAuditor
           size[0] = ''
 
           if (platform == ri.platform) && (size == ri.instance_type) && (value[:count] < 0)
-            until (ri.count == 0) || (value[:count] == 0)
+            until (ri.mutable_count == 0) || (value[:count] == 0)
               value[:count] = value[:count] + 1
-              ri.count = ri.count - 1
+              ri.mutable_count = ri.mutable_count - 1
             end
           end
         end
       end
 
       ris_region.each do |ri|
-        differences[ri.to_s] = {:count => ri.count, :region_based => true}
+        differences[ri.to_s] = {:count => ri.mutable_count, :region_based => true}
+        ri.mutable_count = nil
       end
     end
 

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -55,7 +55,7 @@ module SportNginAwsAuditor
 
     def apply_region_ris(ris_region, differences)
       ris_region.each do |ri|
-        ri.mutable_count_remaining = ri.count
+        ri.count_remaining = ri.count
 
         differences.each do |key, value|
           # if key = 'Linux VPC us-east-1a t2.medium'...
@@ -70,17 +70,17 @@ module SportNginAwsAuditor
           size[0] = ''
 
           if (platform == ri.platform) && (size == ri.instance_type) && (value[:count] < 0)
-            until (ri.mutable_count_remaining == 0) || (value[:count] == 0)
+            until (ri.count_remaining == 0) || (value[:count] == 0)
               value[:count] = value[:count] + 1
-              ri.mutable_count_remaining = ri.mutable_count_remaining - 1
+              ri.count_remaining = ri.count_remaining - 1
             end
           end
         end
       end
 
       ris_region.each do |ri|
-        differences[ri.to_s] = {:count => ri.mutable_count_remaining, :region_based => true}
-        ri.mutable_count_remaining = nil
+        differences[ri.to_s] = {:count => ri.count_remaining, :region_based => true}
+        ri.count_remaining = nil
       end
     end
 

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -13,7 +13,7 @@ module SportNginAwsAuditor
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-01',
                                                availability_zone: 'us-east-1b',
-                                               mutable_count: nil)
+                                               mutable_count_remaining: nil)
       @ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
                                                instance_type: "t2.medium",
                                                vpc_id: "vpc-alsofake",
@@ -24,7 +24,7 @@ module SportNginAwsAuditor
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-02',
                                                availability_zone: 'us-east-1b',
-                                               mutable_count: nil)
+                                               mutable_count_remaining: nil)
       @reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -33,7 +33,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 2,
                                                                 scope: 'Availability Zone',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count: nil)
+                                                                mutable_count_remaining: nil)
       @reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -42,7 +42,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 4,
                                                                 scope: 'Availability Zone',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count: nil)
+                                                                mutable_count_remaining: nil)
       @region_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -51,7 +51,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 2,
                                                                 scope: 'Region',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count: nil)
+                                                                mutable_count_remaining: nil)
       @region_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 4,
                                                                 scope: 'Region',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count: nil)
+                                                                mutable_count_remaining: nil)
       @ec2_instances = [@ec2_instance1, @ec2_instance2]
       @reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1]
       @region_reserved_instances = [@region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
@@ -90,10 +90,10 @@ module SportNginAwsAuditor
       allow(@region_reserved_ec2_instance2).to receive(:count).and_return(4)
       allow(@region_reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC  t2.small')
       allow(@region_reserved_ec2_instance2).to receive(:to_s).and_return('Windows  t2.medium')
-      allow(@region_reserved_ec2_instance1).to receive(:mutable_count).and_return(2)
-      allow(@region_reserved_ec2_instance2).to receive(:mutable_count).and_return(2)
-      allow(@region_reserved_ec2_instance1).to receive(:mutable_count=).and_return(2)
-      allow(@region_reserved_ec2_instance2).to receive(:mutable_count=).and_return(2)
+      allow(@region_reserved_ec2_instance1).to receive(:mutable_count_remaining).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:mutable_count_remaining).and_return(2)
+      allow(@region_reserved_ec2_instance1).to receive(:mutable_count_remaining=).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:mutable_count_remaining=).and_return(2)
     end
 
     context '#instance_count_hash' do

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -12,7 +12,8 @@ module SportNginAwsAuditor
                                                tags: nil,
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-01',
-                                               availability_zone: 'us-east-1b')
+                                               availability_zone: 'us-east-1b',
+                                               mutable_count: nil)
       @ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
                                                instance_type: "t2.medium",
                                                vpc_id: "vpc-alsofake",
@@ -22,7 +23,8 @@ module SportNginAwsAuditor
                                                tags: nil,
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-02',
-                                               availability_zone: 'us-east-1b')
+                                               availability_zone: 'us-east-1b',
+                                               mutable_count: nil)
       @reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -30,7 +32,8 @@ module SportNginAwsAuditor
                                                                 availability_zone: "us-east-1b",
                                                                 instance_count: 2,
                                                                 scope: 'Availability Zone',
-                                                                class: "Aws::EC2::Types::ReservedInstances")
+                                                                class: "Aws::EC2::Types::ReservedInstances",
+                                                                mutable_count: nil)
       @reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -38,7 +41,8 @@ module SportNginAwsAuditor
                                                                 availability_zone: "us-east-1b",
                                                                 instance_count: 4,
                                                                 scope: 'Availability Zone',
-                                                                class: "Aws::EC2::Types::ReservedInstances")
+                                                                class: "Aws::EC2::Types::ReservedInstances",
+                                                                mutable_count: nil)
       @region_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -46,7 +50,8 @@ module SportNginAwsAuditor
                                                                 availability_zone: nil,
                                                                 instance_count: 2,
                                                                 scope: 'Region',
-                                                                class: "Aws::EC2::Types::ReservedInstances")
+                                                                class: "Aws::EC2::Types::ReservedInstances",
+                                                                mutable_count: nil)
       @region_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -54,7 +59,8 @@ module SportNginAwsAuditor
                                                                 availability_zone: nil,
                                                                 instance_count: 4,
                                                                 scope: 'Region',
-                                                                class: "Aws::EC2::Types::ReservedInstances")
+                                                                class: "Aws::EC2::Types::ReservedInstances",
+                                                                mutable_count: nil)
       @ec2_instances = [@ec2_instance1, @ec2_instance2]
       @reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1]
       @region_reserved_instances = [@region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
@@ -84,6 +90,10 @@ module SportNginAwsAuditor
       allow(@region_reserved_ec2_instance2).to receive(:count).and_return(4)
       allow(@region_reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC  t2.small')
       allow(@region_reserved_ec2_instance2).to receive(:to_s).and_return('Windows  t2.medium')
+      allow(@region_reserved_ec2_instance1).to receive(:mutable_count).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:mutable_count).and_return(2)
+      allow(@region_reserved_ec2_instance1).to receive(:mutable_count=).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:mutable_count=).and_return(2)
     end
 
     context '#instance_count_hash' do
@@ -120,7 +130,7 @@ module SportNginAwsAuditor
         end
         result = klass.apply_region_ris(@region_reserved_instances, differences)
         expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 0, region_based: false},
-                                   "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
+                                   "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 2, region_based: true}})
       end
 
       it 'should factor in the region based RIs into the counting when there are no zone specific RIs' do
@@ -132,7 +142,7 @@ module SportNginAwsAuditor
         instance_hash = klass.instance_count_hash(@ec2_instances)
         result = klass.apply_region_ris(@region_reserved_instances, instance_hash)
         expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 5, region_based: false},
-                                     "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
+                                     "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 2, region_based: true}})
       end
     end
 

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -13,7 +13,7 @@ module SportNginAwsAuditor
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-01',
                                                availability_zone: 'us-east-1b',
-                                               mutable_count_remaining: nil)
+                                               count_remaining: nil)
       @ec2_instance2 = double('ec2_instance', instance_id: "i-thisisfake",
                                                instance_type: "t2.medium",
                                                vpc_id: "vpc-alsofake",
@@ -24,7 +24,7 @@ module SportNginAwsAuditor
                                                class: "Aws::EC2::Types::Instance",
                                                key_name: 'Example-instance-02',
                                                availability_zone: 'us-east-1b',
-                                               mutable_count_remaining: nil)
+                                               count_remaining: nil)
       @reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -33,7 +33,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 2,
                                                                 scope: 'Availability Zone',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count_remaining: nil)
+                                                                count_remaining: nil)
       @reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -42,7 +42,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 4,
                                                                 scope: 'Availability Zone',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count_remaining: nil)
+                                                                count_remaining: nil)
       @region_reserved_ec2_instance1 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisalsofake",
                                                                 instance_type: "t2.small",
                                                                 product_description: "Linux/UNIX (Amazon VPC)",
@@ -51,7 +51,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 2,
                                                                 scope: 'Region',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count_remaining: nil)
+                                                                count_remaining: nil)
       @region_reserved_ec2_instance2 = double('reserved_ec2_instance', reserved_instances_id: "12345-dfas-1234-asdf-thisisfake!!",
                                                                 instance_type: "t2.medium",
                                                                 product_description: "Windows",
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
                                                                 instance_count: 4,
                                                                 scope: 'Region',
                                                                 class: "Aws::EC2::Types::ReservedInstances",
-                                                                mutable_count_remaining: nil)
+                                                                count_remaining: nil)
       @ec2_instances = [@ec2_instance1, @ec2_instance2]
       @reserved_instances = [@reserved_ec2_instance2, @reserved_ec2_instance1]
       @region_reserved_instances = [@region_reserved_ec2_instance2, @region_reserved_ec2_instance1]
@@ -90,10 +90,10 @@ module SportNginAwsAuditor
       allow(@region_reserved_ec2_instance2).to receive(:count).and_return(4)
       allow(@region_reserved_ec2_instance1).to receive(:to_s).and_return('Linux VPC  t2.small')
       allow(@region_reserved_ec2_instance2).to receive(:to_s).and_return('Windows  t2.medium')
-      allow(@region_reserved_ec2_instance1).to receive(:mutable_count_remaining).and_return(2)
-      allow(@region_reserved_ec2_instance2).to receive(:mutable_count_remaining).and_return(2)
-      allow(@region_reserved_ec2_instance1).to receive(:mutable_count_remaining=).and_return(2)
-      allow(@region_reserved_ec2_instance2).to receive(:mutable_count_remaining=).and_return(2)
+      allow(@region_reserved_ec2_instance1).to receive(:count_remaining).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:count_remaining).and_return(2)
+      allow(@region_reserved_ec2_instance1).to receive(:count_remaining=).and_return(2)
+      allow(@region_reserved_ec2_instance2).to receive(:count_remaining=).and_return(2)
     end
 
     context '#instance_count_hash' do


### PR DESCRIPTION
Description and Impact
----------------------
When the auditor is run multiple times close together the auditor caches the data for the instances and RIs. And the method `apply_region_ris` was editing the count of each RI (which was what I had originally intended). But a side effect is that when the counts are edited, the cached versions are also edited, so following runs of the auditor causes the RI counts to start off as incorrect.

This PR adds another little part of the ec2instance object: `mutable_count` that we can actively change in `apply_region_ris` without affecting the original count number of the cached RIs.

Deploy Plan
-----------
- checkout master
- `op accept-pull 25`
- `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Verify that running the auditor multiple times does not yield any incorrect counts
- [ ] Regression testing based on current master