### PR TITLE
Automatically ignore instances based on a regex string

### DIFF
--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -50,7 +50,7 @@ module SportNginAwsAuditor
       instances_with_tag = self.klass.filter_instances_with_tags(instances)
       instances_without_tag = self.klass.filter_instances_without_tags(instances)
       instance_hash = self.klass.instance_count_hash(instances_without_tag)
-      self.klass.apply_tagged_instances(instances_with_tag, instance_hash)
+      self.klass.add_additional_instances_to_hash(instances_with_tag, instance_hash, " with tag (")
 
       return instance_hash, retired_tags
     end

--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -3,11 +3,12 @@ require_relative './instance_helper'
 module SportNginAwsAuditor
   class AuditData
 
-    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region
-    def initialize(instances, reserved, class_type, tag_name)
+    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region, :ignore_instances_regex
+    def initialize(instances, reserved, class_type, tag_name, ignore_instances_regex)
       self.selected_audit_type = (!instances && !reserved) ? "all" : (instances ? "instances" : "reserved")
       self.klass = SportNginAwsAuditor.const_get(class_type)
       self.tag_name = tag_name
+      self.ignore_instances_regex = ignore_instances_regex
     end
 
     def instances?
@@ -59,7 +60,7 @@ module SportNginAwsAuditor
       instances = self.klass.get_instances(tag_name)
       gather_region(instances)
       retired_tags = self.klass.get_retired_tags(instances)
-      instance_hash = self.klass.compare(instances)
+      instance_hash = self.klass.compare(instances, ignore_instances_regex)
       retired_ris = self.klass.get_recent_retired_reserved_instances
 
       return instance_hash, retired_tags, retired_ris

--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -3,12 +3,12 @@ require_relative './instance_helper'
 module SportNginAwsAuditor
   class AuditData
 
-    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region, :ignore_instances_regex
-    def initialize(instances, reserved, class_type, tag_name, ignore_instances_regex)
+    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region, :ignore_instances_regexes
+    def initialize(instances, reserved, class_type, tag_name, ignore_instances_regexes)
       self.selected_audit_type = (!instances && !reserved) ? "all" : (instances ? "instances" : "reserved")
       self.klass = SportNginAwsAuditor.const_get(class_type)
       self.tag_name = tag_name
-      self.ignore_instances_regex = ignore_instances_regex
+      self.ignore_instances_regexes = ignore_instances_regexes
     end
 
     def instances?
@@ -60,7 +60,7 @@ module SportNginAwsAuditor
       instances = self.klass.get_instances(tag_name)
       gather_region(instances)
       retired_tags = self.klass.get_retired_tags(instances)
-      instance_hash = self.klass.compare(instances, ignore_instances_regex)
+      instance_hash = self.klass.compare(instances, ignore_instances_regexes)
       retired_ris = self.klass.get_recent_retired_reserved_instances
 
       return instance_hash, retired_tags, retired_ris

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -11,7 +11,7 @@ command 'audit' do |c|
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.switch [:z, :zone_output], :desc => "Will print the Missing RIs and Tagged instances with zones"
-  c.flag [:g, :ignore_instances_strings], :default_value => "kitchen, auto", :desc => "Ignore instances if an instance contains
+  c.flag [:g, :ignore_instances_patterns], :default_value => "kitchen, auto", :desc => "Ignore instances if an instance contains
                                                                                 one of these strings in the name,
                                                                                 pass in like: string1, string2, string3"
   c.action do |global_options, options, args|

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -11,6 +11,9 @@ command 'audit' do |c|
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.switch [:z, :zone_output], :desc => "Will print the Missing RIs and Tagged instances with zones"
+  c.flag [:g, :ignore_instances_regex], :default_value => "kitchen, auto", :desc => "Ignore instances if an instance contains
+                                                                                one of these strings in the name,
+                                                                                pass in like: regex1, regex2, regex3"
   c.action do |global_options, options, args|
     require_relative '../scripts/audit'
     raise ArgumentError, 'You must specify an AWS account' unless args.first

--- a/lib/sport_ngin_aws_auditor/commands/audit.rb
+++ b/lib/sport_ngin_aws_auditor/commands/audit.rb
@@ -11,9 +11,9 @@ command 'audit' do |c|
   c.switch [:n, :no_tag], :desc => "Ignore all tags during audit"
   c.switch [:s, :slack], :desc => "Will print condensed version of audit to a Slack channel"
   c.switch [:z, :zone_output], :desc => "Will print the Missing RIs and Tagged instances with zones"
-  c.flag [:g, :ignore_instances_regex], :default_value => "kitchen, auto", :desc => "Ignore instances if an instance contains
+  c.flag [:g, :ignore_instances_strings], :default_value => "kitchen, auto", :desc => "Ignore instances if an instance contains
                                                                                 one of these strings in the name,
-                                                                                pass in like: regex1, regex2, regex3"
+                                                                                pass in like: string1, string2, string3"
   c.action do |global_options, options, args|
     require_relative '../scripts/audit'
     raise ArgumentError, 'You must specify an AWS account' unless args.first

--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -7,42 +7,61 @@ module SportNginAwsAuditor
     attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based
     def initialize(type, data_hash, region)
       if type.include?(" with tag")
-        type = type.dup # because type is a frozen string right now
-        type.slice!(" with tag")
-        self.type = type
-        self.category = "tagged"
-        self.name = data_hash[:name] || nil
-        self.reason = data_hash[:tag_reason] || nil
-        self.tag_value = data_hash[:tag_value] || nil
-        self.region_based = data_hash[:region_based] || nil
+        gather_tagged_data(type, data_hash, region)
+      elsif type.include?(" ignored")
+        gather_ignored_data(type, data_hash, region)
       else
-        self.region_based = data_hash[:region_based] || nil
-
-        if data_hash[:count] < 0
-          self.category = "running"
-        elsif data_hash[:count] == 0
-          self.category = "matched"
-        elsif data_hash[:count] > 0
-          self.category = "reserved"
-        end
-
-        if region_based?
-          # if type = 'Linux VPC  t2.small'...
-          my_match = type.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
-
-          # then platform = 'Linux VPC '...
-          platform = my_match[1] if my_match
-
-          # and size = 't2.small'
-          size = my_match[2] if my_match
-
-          self.type = platform << region << ' ' << size
-        else
-          self.type = type
-        end
+        gather_normal_data(type, data_hash, region)
       end
 
       self.count = data_hash[:count].abs
+    end
+
+    def gather_tagged_data(type, data_hash, region)
+      type = type.dup # because type is a frozen string right now
+      type.slice!(" with tag")
+      self.type = type
+      self.category = "tagged"
+      self.name = data_hash[:name] || nil
+      self.reason = data_hash[:tag_reason] || nil
+      self.tag_value = data_hash[:tag_value] || nil
+      self.region_based = data_hash[:region_based] || nil
+    end
+
+    def gather_ignored_data(type, data_hash, region)
+      type = type.dup
+      type.slice!(" ignored")
+      self.type = type
+      self.category = "ignored"
+      self.name = data_hash[:name] || nil
+      self.region_based = data_hash[:region_based] || nil
+    end
+
+    def gather_normal_data(type, data_hash, region)
+      self.region_based = data_hash[:region_based] || nil
+
+      if data_hash[:count] < 0
+        self.category = "running"
+      elsif data_hash[:count] == 0
+        self.category = "matched"
+      elsif data_hash[:count] > 0
+        self.category = "reserved"
+      end
+
+      if region_based?
+        # if type = 'Linux VPC  t2.small'...
+        my_match = type.match(/(\w*\s*\w*\s{1})\s*(\s*\S*)/)
+
+        # then platform = 'Linux VPC '...
+        platform = my_match[1] if my_match
+
+        # and size = 't2.small'
+        size = my_match[2] if my_match
+
+        self.type = platform << region << ' ' << size
+      else
+        self.type = type
+      end
     end
 
     def region_based?
@@ -51,6 +70,10 @@ module SportNginAwsAuditor
 
     def tagged?
       self.category == "tagged"
+    end
+
+    def ignored?
+      self.category == "ignored"
     end
 
     def reserved?

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -94,8 +94,8 @@ module SportNginAwsAuditor
 
     #################### PARSING AND COMPARING DATA ####################
 
-    def sort_through_instances(instances)
-      ignored_instances, not_ignored_instances = filter_ignored_instances(instances)
+    def sort_through_instances(instances, ignore_instances_regex)
+      ignored_instances, not_ignored_instances = filter_ignored_instances(instances, ignore_instances_regex)
       instances_with_tag = filter_instances_with_tags(not_ignored_instances)
       instances_without_tag = filter_instances_without_tags(not_ignored_instances)
       instance_hash = instance_count_hash(instances_without_tag)
@@ -127,8 +127,8 @@ module SportNginAwsAuditor
       return differences
     end
 
-    def compare(instances)
-      ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances)
+    def compare(instances, ignore_instances_regex)
+      ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances, ignore_instances_regex)
       ris_region, ris_hash = sort_through_RIs
       differences = measure_differences(instance_hash, ris_hash)
       add_additional_data(ris_region, instances_with_tag, ignored_instances, differences)
@@ -163,9 +163,10 @@ module SportNginAwsAuditor
       ris.select { |ri| ri.scope == 'Region' }
     end
 
-    # this breaks up the instances array into instances with 'auto' or 'kitchen' in the name and instances without
-    def filter_ignored_instances(instances)
-      instances.partition { |instance| instance.name.include?("auto") || instance.name.include?("kitchen") }
+    # this breaks up the instances array into instances with any of the strings in the ignore_instances_regex and
+    # instances without
+    def filter_ignored_instances(instances, ignore_instances_regex)
+      instances.partition { |instance| ignore_instances_regex.any? { |regex| instance.name ? instance.name.include?(regex) : false} }
     end
 
     #################### GATHERING RETIRED DATA ####################

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -12,6 +12,8 @@ module SportNginAwsAuditor
       Hash[get_reserved_instances.map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 
+    #################### ADDING DATA TO HASH ####################
+
     def instance_count_hash(instances)
       instance_hash = Hash.new()
       instances.each do |instance|
@@ -25,35 +27,7 @@ module SportNginAwsAuditor
       instance_hash
     end
 
-    def apply_tagged_instances(instances_to_add, instance_hash)
-      instances_to_add.each do |instance|
-        next if instance.nil?
-        key = instance.to_s.dup << " with tag (" << instance.name << ")"
-        instance_result = {}
-        
-        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0
-          current_val = instance_hash[instance.to_s][:count]
-          val = current_val - instance.count
-          new_val = val >= 0 ? val : 0
-          instance_hash[instance.to_s][:count] = new_val
-
-          val = instance.count - current_val
-          new_val = val >= 0 ? val : 0
-          instance_result[:count] = new_val
-        else
-          instance_result[:count] = instance.count
-        end
-
-        instance_result.merge!({:name => instance.name, :tag_reason => instance.tag_reason,
-                                :tag_value => instance.tag_value, :region_based => false})
-
-        instance_hash[key] = instance_result
-      end if instances_to_add
-
-      instance_hash
-    end
-
-    def apply_region_ris(ris_region, differences)
+    def add_region_ris_to_hash(ris_region, differences)
       ris_region.each do |ri|
         differences.each do |key, value|
           # if key = 'Linux VPC us-east-1a t2.medium'...
@@ -81,6 +55,61 @@ module SportNginAwsAuditor
       end
     end
 
+    def add_additional_instances_to_hash(instances_to_add, instance_hash, extra_string)
+      instances_to_add.each do |instance|
+        next if instance.nil?
+        key = instance.to_s.dup << extra_string << instance.name << ")"
+        instance_result = {}
+        
+        if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0
+          current_val = instance_hash[instance.to_s][:count]
+          val = current_val - instance.count
+          new_val = val >= 0 ? val : 0
+          instance_hash[instance.to_s][:count] = new_val
+
+          val = instance.count - current_val
+          new_val = val >= 0 ? val : 0
+          instance_result[:count] = new_val
+        else
+          instance_result[:count] = instance.count
+        end
+
+        merged_hash = gather_hash(extra_string, instance)
+        instance_result.merge!(merged_hash)
+
+        instance_hash[key] = instance_result
+      end if instances_to_add
+
+      instance_hash
+    end
+
+    def gather_hash(extra_string, instance)
+      if extra_string.include?("tag")
+        {:name => instance.name, :tag_reason => instance.tag_reason,
+         :tag_value => instance.tag_value, :region_based => false}
+      elsif extra_string.include?("ignore")
+        {:name => instance.name, :region_based => false}
+      end
+    end
+
+    #################### PARSING AND COMPARING DATA ####################
+
+    def sort_through_instances(instances)
+      ignored_instances, not_ignored_instances = filter_ignored_instances(instances)
+      instances_with_tag = filter_instances_with_tags(not_ignored_instances)
+      instances_without_tag = filter_instances_without_tags(not_ignored_instances)
+      instance_hash = instance_count_hash(instances_without_tag)
+      return ignored_instances, instances_with_tag, instance_hash
+    end
+
+    def sort_through_RIs
+      ris = get_reserved_instances
+      ris_availability = filter_ris_availability_zone(ris)
+      ris_region = filter_ris_region_based(ris)
+      ris_hash = instance_count_hash(ris_availability)
+      return ris_region, ris_hash
+    end
+
     def measure_differences(instance_hash, ris_hash)
       differences = Hash.new()
       instance_hash.keys.concat(ris_hash.keys).uniq.each do |key|
@@ -91,29 +120,22 @@ module SportNginAwsAuditor
       differences
     end
 
-    def compare(instances)
-      instances_with_tag = filter_instances_with_tags(instances)
-      instances_without_tag = filter_instances_without_tags(instances)
-      instance_hash = instance_count_hash(instances_without_tag)
+    def add_additional_data(ris_region, instances_with_tag, ignored_instances, differences)
+      add_region_ris_to_hash(ris_region, differences)
+      add_additional_instances_to_hash(instances_with_tag, differences, " with tag (")
+      add_additional_instances_to_hash(ignored_instances, differences, " ignored (")
+      return differences
+    end
 
-      ris = get_reserved_instances
-      ris_availability = filter_ris_availability_zone(ris)
-      ris_region = filter_ris_region_based(ris)
-      ris_hash = instance_count_hash(ris_availability)
-      
+    def compare(instances)
+      ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances)
+      ris_region, ris_hash = sort_through_RIs
       differences = measure_differences(instance_hash, ris_hash)
-      apply_region_ris(ris_region, differences)
-      apply_tagged_instances(instances_with_tag, differences)
+      add_additional_data(ris_region, instances_with_tag, ignored_instances, differences)
       differences
     end
 
-    # this gets all retired reserved instances and filters out only the ones that have expired
-    # within the past week
-    def get_recent_retired_reserved_instances
-      get_retired_reserved_instances.select do |ri|
-        ri.expiration_date > (Time.now - 604800)
-      end
-    end
+    #################### FILTERING ACTIVE DATA ####################
 
     # assuming the value of the tag is in the form: 01/01/2000 like a date
     def filter_instances_with_tags(instances)
@@ -139,6 +161,20 @@ module SportNginAwsAuditor
     # this filters all of the region-based RIs
     def filter_ris_region_based(ris)
       ris.select { |ri| ri.scope == 'Region' }
+    end
+
+    def filter_ignored_instances(instances)
+      instances.partition { |instance| instance.name.include?("auto") || instance.name.include?("kitchen") }
+    end
+
+    #################### GATHERING RETIRED DATA ####################
+
+    # this gets all retired reserved instances and filters out only the ones that have expired
+    # within the past week
+    def get_recent_retired_reserved_instances
+      get_retired_reserved_instances.select do |ri|
+        ri.expiration_date > (Time.now - 604800)
+      end
     end
 
     # this returns a hash of all instances that have retired between 1 week ago and today

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -94,8 +94,8 @@ module SportNginAwsAuditor
 
     #################### PARSING AND COMPARING DATA ####################
 
-    def sort_through_instances(instances, ignore_instances_regex)
-      ignored_instances, not_ignored_instances = filter_ignored_instances(instances, ignore_instances_regex)
+    def sort_through_instances(instances, ignore_instances_regexes)
+      ignored_instances, not_ignored_instances = filter_ignored_instances(instances, ignore_instances_regexes)
       instances_with_tag = filter_instances_with_tags(not_ignored_instances)
       instances_without_tag = filter_instances_without_tags(not_ignored_instances)
       instance_hash = instance_count_hash(instances_without_tag)
@@ -127,8 +127,8 @@ module SportNginAwsAuditor
       return differences
     end
 
-    def compare(instances, ignore_instances_regex)
-      ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances, ignore_instances_regex)
+    def compare(instances, ignore_instances_regexes)
+      ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances, ignore_instances_regexes)
       ris_region, ris_hash = sort_through_RIs
       differences = measure_differences(instance_hash, ris_hash)
       add_additional_data(ris_region, instances_with_tag, ignored_instances, differences)
@@ -163,10 +163,14 @@ module SportNginAwsAuditor
       ris.select { |ri| ri.scope == 'Region' }
     end
 
-    # this breaks up the instances array into instances with any of the strings in the ignore_instances_regex and
+    # this breaks up the instances array into instances with any of the strings in the ignore_instances_regexes and
     # instances without
-    def filter_ignored_instances(instances, ignore_instances_regex)
-      instances.partition { |instance| ignore_instances_regex.any? { |regex| instance.name ? instance.name.include?(regex) : false} }
+    def filter_ignored_instances(instances, ignore_instances_regexes)
+      instances.partition { |instance|
+        ignore_instances_regexes.any? { |regex|
+          instance.name ? instance.name.match(regex) != nil : false
+        }
+      }
     end
 
     #################### GATHERING RETIRED DATA ####################

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -25,9 +25,9 @@ module SportNginAwsAuditor
           tag_name = options[:tag]
         end
 
-        ignore_instances_strings = options[:ignore_instances_strings].split(', ') if options[:ignore_instances_strings]
+        ignore_instances_patterns = options[:ignore_instances_patterns].split(', ') if options[:ignore_instances_patterns]
         ignore_instances_regexes = []
-        ignore_instances_strings.each do |r|
+        ignore_instances_patterns.each do |r|
           ignore_instances_regexes << Regexp.new(r)
         end
         zone_output = options[:zone_output]

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -25,7 +25,11 @@ module SportNginAwsAuditor
           tag_name = options[:tag]
         end
 
-        ignore_instances_regex = options[:ignore_instances_regex].split(', ') if options[:ignore_instances_regex]
+        ignore_instances_strings = options[:ignore_instances_strings].split(', ') if options[:ignore_instances_strings]
+        ignore_instances_regexes = []
+        ignore_instances_strings.each do |r|
+          ignore_instances_regexes << Regexp.new(r)
+        end
         zone_output = options[:zone_output]
 
         cycle = [["EC2Instance", options[:ec2]],
@@ -39,7 +43,7 @@ module SportNginAwsAuditor
         end
 
         cycle.each do |c|
-          audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regex)
+          audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regexes)
           audit_results.gather_data
           output_options = {:slack => slack, :class_type => c.first,
                             :environment => environment, :zone_output => zone_output}

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -25,11 +25,12 @@ module SportNginAwsAuditor
           tag_name = options[:tag]
         end
 
+        ignore_instances_regex = options[:ignore_instances_regex].split(', ') if options[:ignore_instances_regex]
         zone_output = options[:zone_output]
 
-        cycle = [["EC2Instance", options[:ec2]]]#,
-                # ["RDSInstance", options[:rds]],
-                # ["CacheInstance", options[:cache]]]
+        cycle = [["EC2Instance", options[:ec2]],
+                ["RDSInstance", options[:rds]],
+                ["CacheInstance", options[:cache]]]
 
         if !slack
           print "Gathering info, please wait..."; print "\r"
@@ -38,7 +39,7 @@ module SportNginAwsAuditor
         end
 
         cycle.each do |c|
-          audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name)
+          audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regex)
           audit_results.gather_data
           output_options = {:slack => slack, :class_type => c.first,
                             :environment => environment, :zone_output => zone_output}

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -17,8 +17,8 @@ module SportNginAwsAuditor
       allow(SportNginAwsAuditor::EC2Instance).to receive(:filter_instances_without_tags).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:instance_count_hash).and_return({'instance1' => 1,
                                                                                            'instance2' => 1})
-      allow(SportNginAwsAuditor::EC2Instance).to receive(:apply_tagged_instances).and_return({'instance1' => 1,
-                                                                                                      'instance2' => 1})
+      allow(SportNginAwsAuditor::EC2Instance).to receive(:add_additional_instances_to_hash).and_return({'instance1' => 1,
+                                                                                                        'instance2' => 1})
       allow(SportNginAwsAuditor::EC2Instance).to receive(:compare).and_return({'instance1' => 1,
                                                                                'instance2' => 1})
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_recent_retired_reserved_instances).and_return(@retired_ris)

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -10,7 +10,7 @@ module SportNginAwsAuditor
       @instance4 = double('ec2_instance4')
       @ec2_instances = [@instance1, @instance2]
       @retired_ris = [@instance3, @instance4]
-      @ignore_instances_regex = ["kitchen", "auto"]
+      @ignore_instances_regexes = ["kitchen", "auto"]
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
@@ -28,75 +28,75 @@ module SportNginAwsAuditor
 
     context '#initialization' do
       it 'should gather instance data' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather reserved instance data' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.selected_audit_type).to eq("reserved")
       end
 
       it 'should by default gather instance data' do
-        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather all data to compare' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.selected_audit_type).to eq("all")
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.klass).to eq(SportNginAwsAuditor::EC2Instance)
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.tag_name).to eq("no-reserved-instance")
       end
     end
 
     context '#instances?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.instances?).to eq(true)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.instances?).to eq(false)
       end
     end
 
     context '#reserved?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.reserved?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.reserved?).to eq(true)
       end
     end
 
     context '#all?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.all?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         expect(audit_results.all?).to eq(true)
       end
     end
 
     context '#gather_data' do
       it 'should gather some empty results by comparison' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -104,7 +104,7 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just instances' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -112,7 +112,7 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just reserved' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq(nil)
@@ -122,7 +122,7 @@ module SportNginAwsAuditor
 
     context '#gather_instances_data' do
       it 'should gather some instances data but not convert' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         result1, result2 = audit_results.gather_instances_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
@@ -131,7 +131,7 @@ module SportNginAwsAuditor
 
     context '#gather_all_data' do
       it 'should gather some comparison data but not convert' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         result1, result2, result3 = audit_results.gather_all_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
@@ -141,7 +141,7 @@ module SportNginAwsAuditor
 
     context '#gather_region' do
       it 'should gather the region from an instance' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
         audit_results.gather_region(@ec2_instances)
         expect(audit_results.region).to eq('us-east')
       end

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -10,6 +10,7 @@ module SportNginAwsAuditor
       @instance4 = double('ec2_instance4')
       @ec2_instances = [@instance1, @instance2]
       @retired_ris = [@instance3, @instance4]
+      @ignore_instances_regex = ["kitchen", "auto"]
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_reserved_instances).and_return(@ec2_instances)
       allow(SportNginAwsAuditor::EC2Instance).to receive(:get_retired_tags).and_return([])
@@ -27,75 +28,75 @@ module SportNginAwsAuditor
 
     context '#initialization' do
       it 'should gather instance data' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather reserved instance data' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.selected_audit_type).to eq("reserved")
       end
 
       it 'should by default gather instance data' do
-        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather all data to compare' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.selected_audit_type).to eq("all")
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.klass).to eq(SportNginAwsAuditor::EC2Instance)
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.tag_name).to eq("no-reserved-instance")
       end
     end
 
     context '#instances?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.instances?).to eq(true)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.instances?).to eq(false)
       end
     end
 
     context '#reserved?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.reserved?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.reserved?).to eq(true)
       end
     end
 
     context '#all?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.all?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         expect(audit_results.all?).to eq(true)
       end
     end
 
     context '#gather_data' do
       it 'should gather some empty results by comparison' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -103,7 +104,7 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just instances' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -111,7 +112,7 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just reserved' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq(nil)
@@ -121,7 +122,7 @@ module SportNginAwsAuditor
 
     context '#gather_instances_data' do
       it 'should gather some instances data but not convert' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         result1, result2 = audit_results.gather_instances_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
@@ -130,7 +131,7 @@ module SportNginAwsAuditor
 
     context '#gather_all_data' do
       it 'should gather some comparison data but not convert' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         result1, result2, result3 = audit_results.gather_all_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
@@ -140,7 +141,7 @@ module SportNginAwsAuditor
 
     context '#gather_region' do
       it 'should gather the region from an instance' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance")
+        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regex)
         audit_results.gather_region(@ec2_instances)
         expect(audit_results.region).to eq('us-east')
       end

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -94,16 +94,23 @@ module SportNginAwsAuditor
       end
     end
 
-    context '#apply_tagged_instances' do
+    context '#add_additional_instances_to_hash' do
       it 'should add the instances to the hash of differences' do
         klass = SportNginAwsAuditor::EC2Instance
-        result = klass.apply_tagged_instances(@ec2_instances, {})
+        result = klass.add_additional_instances_to_hash(@ec2_instances, {}, " with tag (")
         expect(result).to eq({'Linux VPC us-east-1b t2.small with tag (Example-instance-01)' => {count: 1, name: @ec2_instance1.key_name, tag_reason: nil, tag_value: nil, region_based: false},
                               'Windows us-east-1b t2.medium with tag (Example-instance-02)' => {count: 1, name: @ec2_instance2.key_name, tag_reason: nil, tag_value: nil, region_based: false}})
       end
+
+      it 'should add the ignored instances to the hash of differences' do
+        klass = SportNginAwsAuditor::EC2Instance
+        result = klass.add_additional_instances_to_hash(@ec2_instances, {}, " ignored (")
+        expect(result).to eq({'Linux VPC us-east-1b t2.small ignored (Example-instance-01)' => {count: 1, name: @ec2_instance1.key_name, region_based: false},
+                              'Windows us-east-1b t2.medium ignored (Example-instance-02)' => {count: 1, name: @ec2_instance2.key_name, region_based: false}})
+      end
     end
 
-    context '#apply_region_ris' do
+    context '#add_region_ris_to_hash' do
       it 'should factor in the region based RIs into the counting when there is a mixture of region based and non region based' do
         klass = SportNginAwsAuditor::EC2Instance
         allow(@ec2_instance1).to receive(:count).and_return(5)
@@ -118,7 +125,7 @@ module SportNginAwsAuditor
           ris_count = ris.has_key?(key) ? ris[key][:count] : 0
           differences[key] = {count: ris_count - instance_count, region_based: false}
         end
-        result = klass.apply_region_ris(@region_reserved_instances, differences)
+        result = klass.add_region_ris_to_hash(@region_reserved_instances, differences)
         expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 0, region_based: false},
                                    "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end
@@ -130,7 +137,7 @@ module SportNginAwsAuditor
         allow(@region_reserved_ec2_instance1).to receive(:count=)
         allow(@region_reserved_ec2_instance2).to receive(:count=)
         instance_hash = klass.instance_count_hash(@ec2_instances)
-        result = klass.apply_region_ris(@region_reserved_instances, instance_hash)
+        result = klass.add_region_ris_to_hash(@region_reserved_instances, instance_hash)
         expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 5, region_based: false},
                                      "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end


### PR DESCRIPTION
Description and Impact
----------------------
Automatically ignore certain running instances if they have the words `kitchen` or `auto` in their title. This should print them in blue (like tagged instances), but will say `IGNORED` instead.

Deploy Plan
-----------
- checkout master
- `op accept-pull 26`
- `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [ ] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit [account]` to see ignored instances print in the terminal
- [ ] Run `GLI_DEBUG=true bin/sport-ngin-aws-auditor audit -s [account]` to see ignored instances print into Slack
- [ ] Compare with a current version of master and verify that the ignored instances in the new version are appearing as Missing RIs in the current version