### PR TITLE
Concat all of the similar values into one value right before printing

### DIFF
--- a/lib/sport_ngin_aws_auditor/instance.rb
+++ b/lib/sport_ngin_aws_auditor/instance.rb
@@ -4,17 +4,24 @@ module SportNginAwsAuditor
   class Instance
     extend InstanceHelper
 
-    attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based
-    def initialize(type, data_hash, region)
-      if type.include?(" with tag")
-        gather_tagged_data(type, data_hash, region)
-      elsif type.include?(" ignored")
-        gather_ignored_data(type, data_hash, region)
+    attr_accessor :type, :count, :category, :tag_value, :reason, :name, :region_based, :replaced
+    def initialize(type, data_hash, region, category=nil, count=nil)
+      if category && count
+        self.type = type
+        self.category = category
+        self.count = count
       else
-        gather_normal_data(type, data_hash, region)
-      end
+        if type.include?(" with tag")
+          gather_tagged_data(type, data_hash, region)
+        elsif type.include?(" ignored")
+          gather_ignored_data(type, data_hash, region)
+        else
+          gather_normal_data(type, data_hash, region)
+        end
 
-      self.count = data_hash[:count].abs
+        self.count = data_hash[:count].abs
+        self.replaced = false
+      end
     end
 
     def gather_tagged_data(type, data_hash, region)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -294,33 +294,30 @@ module SportNginAwsAuditor
         type.sub(/(-\d\w)/, '')
       end
 
-      def self.merge_similar_keys(data)
-        merged_array = []
+      def self.merge_similar_keys(original_data)
+        combined_data = []
 
-        data.each_with_index do |instance, index|
+        original_data.each_with_index do |instance, index|
           new_count = instance.count
 
-          if instance.replaced
-            data.delete(instance)
-            next
-          else
-            for i in index+1..data.length-1
-              if (data[i].type == instance.type) && ((data[i].running? && instance.running?) || 
-                                                     (data[i].reserved? && instance.reserved?) || 
-                                                     (data[i].matched? && instance.matched?))
-                new_count = new_count + data[i].count
-                data[i].replaced = true
+          unless instance.replaced
+            for i in index+1..original_data.length-1
+              if (original_data[i].type == instance.type) && ((original_data[i].running? && instance.running?) ||
+                                                              (original_data[i].reserved? && instance.reserved?) ||
+                                                              (original_data[i].matched? && instance.matched?))
+                new_count = new_count + original_data[i].count
+                original_data[i].replaced = true
               end
             end
 
             if new_count != instance.count
-              merged_array.push(Instance.new(instance.type, nil, nil, instance.category, new_count))
-              data.delete(instance)
+              combined_data.push(Instance.new(instance.type, nil, nil, instance.category, new_count))
+              instance.replaced = true
             end
           end
         end
 
-        data.concat(merged_array)
+        original_data.reject { |instance| instance.replaced }.concat(combined_data)
       end
 
       def self.color_chooser(data)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -264,7 +264,13 @@ module SportNginAwsAuditor
       end
 
       def self.print_message
-        puts @message unless @message == ""
+        unless @message == ""
+          if @slack
+            @slack_message.perform
+          else
+            puts @message
+          end
+        end
       end
 
       def self.add_region_to_message(region)


### PR DESCRIPTION
Description and Impact
----------------------
When there are multiple lines with the same types of instances, as shown in this image, they should be combined into one single line for the specific region.

So here, there should be one line showing that we need 6 c3.4xlarge reserved instances, instead of them being separated by zone (which isn't even showing up when we use the auditor). However, because we want the auditor to support zone-based, whether they're combined should depend on whether the auditor is being run as region-based or zone-based.

<img width="441" alt="screen shot 2016-12-12 at 8 47 41 am" src="https://cloud.githubusercontent.com/assets/7562793/21109504/00c39e86-c05f-11e6-85c8-b0675b1beb19.png">

Deploy Plan
-----------
* `git checkout master`
* `git pull`
* `op accept-pull 27`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run the command in zone-based mode, making sure that data is reflected taking zones into account
- [x] Run the command in region-based mode, making sure that lines are merged together ignoring separate zones