### PR TITLE
Must merge this PR in to run the audit command correctly

### DIFF
--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -58,8 +58,7 @@ module SportNginAwsAuditor
     def add_additional_instances_to_hash(instances_to_add, instance_hash, extra_string)
       instances_to_add.each do |instance|
         next if instance.nil?
-        n = instance.name || ""
-        key = instance.to_s.dup << extra_string << n << ")"
+        key = instance.to_s.dup << extra_string << (instance.name || "") << ")"
         instance_result = {}
         
         if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -58,7 +58,8 @@ module SportNginAwsAuditor
     def add_additional_instances_to_hash(instances_to_add, instance_hash, extra_string)
       instances_to_add.each do |instance|
         next if instance.nil?
-        key = instance.to_s.dup << extra_string << instance.name << ")"
+        n = instance.name || ""
+        key = instance.to_s.dup << extra_string << n << ")"
         instance_result = {}
         
         if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -32,10 +32,12 @@ module SportNginAwsAuditor
             ignore_instances_regexes << Regexp.new(r)
           end
         end
+        
+        zone_output = options[:zone_output]
 
         cycle = [["EC2Instance", options[:ec2]],
-                ["RDSInstance", options[:rds]],
-                ["CacheInstance", options[:cache]]]
+                 ["RDSInstance", options[:rds]],
+                 ["CacheInstance", options[:cache]]]
 
         if !slack
           print "Gathering info, please wait..."; print "\r"

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -25,12 +25,13 @@ module SportNginAwsAuditor
           tag_name = options[:tag]
         end
 
-        ignore_instances_patterns = options[:ignore_instances_patterns].split(', ') if options[:ignore_instances_patterns]
         ignore_instances_regexes = []
-        ignore_instances_patterns.each do |r|
-          ignore_instances_regexes << Regexp.new(r)
+        if options[:ignore_instances_patterns]
+          ignore_instances_patterns = options[:ignore_instances_patterns].split(', ')
+          ignore_instances_patterns.each do |r|
+            ignore_instances_regexes << Regexp.new(r)
+          end
         end
-        zone_output = options[:zone_output]
 
         cycle = [["EC2Instance", options[:ec2]],
                 ["RDSInstance", options[:rds]],


### PR DESCRIPTION
Description and Impact
----------------------
Fix bug where the auditor will break if `instance.name` is nil, and a bug where the auditor will error if no regex patterns are passed in.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
 - [x] Run the command and verify it works

The two errors I've seen here are one on line 30 of `lib/sport_ngin_aws_auditor/scripts/audit.rb` (undefined method 'each' for nil) and one on line 61 of `lib/sport_ngin_aws_auditor/instance_helper.rb`(no implicit conversion of nil into string)