### PR TITLE
We actually do not want to cache the counts of instances and reserved instances between multiple runs

### DIFF
--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -30,12 +30,13 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :instance_type, :scope, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :instance_type, :scope, :engine, :count, :tag_value, :tag_reason, :expiration_date, :availability_zone
     def initialize(cache_instance, account_id=nil, tag_name=nil, cache=nil)
       if cache_instance.class.to_s == "Aws::ElastiCache::Types::ReservedCacheNode"
         self.id = cache_instance.reserved_cache_node_id
         self.name = cache_instance.reserved_cache_node_id
         self.scope = nil
+        self.availability_zone = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.product_description
         self.count = cache_instance.cache_node_count
@@ -44,6 +45,7 @@ module SportNginAwsAuditor
         self.id = cache_instance.cache_cluster_id
         self.name = cache_instance.cache_cluster_id
         self.scope = nil
+        self.availability_zone = nil
         self.instance_type = cache_instance.cache_node_type
         self.engine = cache_instance.engine
         self.count = cache_instance.num_cache_nodes

--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -7,28 +7,23 @@ module SportNginAwsAuditor
     extend AWSWrapper
 
     class << self
-      attr_accessor :instances, :reserved_instances, :retired_reserved_instances
-
       def get_instances(tag_name=nil)
-        return @instances if @instances
         account_id = get_account_id
-        @instances = cache.describe_cache_clusters.cache_clusters.map do |instance|
+        cache.describe_cache_clusters.cache_clusters.map do |instance|
           next unless instance.cache_cluster_status.to_s == 'available'
           new(instance, account_id, tag_name, cache)
         end.compact
       end
 
       def get_reserved_instances
-        return @reserved_instances if @reserved_instances
-        @reserved_instances = cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
+        cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
           next unless instance.state.to_s == 'active'
           new(instance)
         end.compact
       end
 
       def get_retired_reserved_instances
-        return @retired_reserved_instances if @retired_reserved_instances
-        @retired_reserved_instances = cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
+        cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
           next unless instance.state == 'retired'
           new(instance)
         end.compact

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -58,7 +58,8 @@ module SportNginAwsAuditor
     def add_additional_instances_to_hash(instances_to_add, instance_hash, extra_string)
       instances_to_add.each do |instance|
         next if instance.nil?
-        key = instance.to_s.dup << extra_string << instance.name << ")"
+        n = instance.name || ""
+        key = instance.to_s.dup << extra_string << n << ")"
         instance_result = {}
         
         if instance_hash.has_key?(instance.to_s) && instance_hash[instance.to_s][:count] > 0

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -7,28 +7,23 @@ module SportNginAwsAuditor
     extend AWSWrapper
 
     class << self
-      attr_accessor :instances, :reserved_instances, :retired_reserved_instances
-
       def get_instances(tag_name=nil)
-        return @instances if @instances
         account_id = get_account_id
-        @instances = rds.describe_db_instances.db_instances.map do |instance|
+        rds.describe_db_instances.db_instances.map do |instance|
           next unless instance.db_instance_status.to_s == 'available'
           new(instance, account_id, tag_name, rds)
         end.compact
       end
 
       def get_reserved_instances
-        return @reserved_instances if @reserved_instances
-        @reserved_instances = rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
+        rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
           next unless instance.state.to_s == 'active'
           new(instance)
         end.compact
       end
 
       def get_retired_reserved_instances
-        return @retired_reserved_instances if @retired_reserved_instances
-        @retired_reserved_instances = rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
+        rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
           next unless instance.state == 'retired'
           new(instance)
         end.compact

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -96,7 +96,7 @@ module SportNginAwsAuditor
         say "The following #{output_options[:class_type]}Instance tags have recently expired in #{output_options[:environment]}:"
         retired_tags.each do |tag|
           if tag.reason
-            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because of #{tag.reason}"
+            say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because #{tag.reason}"
           else
             say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value}"
           end
@@ -110,7 +110,7 @@ module SportNginAwsAuditor
         
         if instance.tagged?
           if instance.reason
-            puts "#{prefix} #{name}: (expiring on #{instance.tag_value} because of #{instance.reason})".blue
+            puts "#{prefix} #{name}: (expiring on #{instance.tag_value} because #{instance.reason})".blue
           else
             say "<%= color('#{prefix} #{name}: (expiring on #{instance.tag_value})', :#{color}) %>"
           end
@@ -168,7 +168,7 @@ module SportNginAwsAuditor
       end
 
       def self.print_tagged(tagged_ignored_array, output_options)
-        title = "There are currently some tagged #{output_options[:class_type]}s in #{output_options[:environment]}:\n"
+        title = "There are currently some tagged or ignored #{output_options[:class_type]}s in #{output_options[:environment]}:\n"
         slack_instances = NotifySlack.new(title, options[:config_json])
 
         tagged_ignored_array.each do |tagged_or_ignored|
@@ -178,7 +178,7 @@ module SportNginAwsAuditor
           
           if tagged_or_ignored.tagged?
             if tagged_or_ignored.reason
-              text = "#{prefix} #{tagged_or_ignored.name}: (expiring on #{tagged_or_ignored.tag_value} because of #{tagged_or_ignored.reason})"
+              text = "#{prefix} #{tagged_or_ignored.name}: (expiring on #{tagged_or_ignored.tag_value} because #{tagged_or_ignored.reason})"
             else
               text = "#{prefix} #{tagged_or_ignored.name}: (expiring on #{tagged_or_ignored.tag_value})"
             end
@@ -227,7 +227,7 @@ module SportNginAwsAuditor
 
         retired_tags.each do |tag|
           if tag.reason
-            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}* because of #{tag.reason}\n"
+            message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}* because #{tag.reason}\n"
           else
             message << "*#{tag.instance_name}* (#{tag.instance_type}) retired on *#{tag.value}*\n"
           end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -26,17 +26,11 @@ module SportNginAwsAuditor
         end
 
         ignore_instances_regexes = []
-<<<<<<< HEAD
-        puts ignore_instances_patterns
-        ignore_instances_patterns.each do |r|
-          ignore_instances_regexes << Regexp.new(r)
-=======
         if options[:ignore_instances_patterns]
           ignore_instances_patterns = options[:ignore_instances_patterns].split(', ')
           ignore_instances_patterns.each do |r|
             ignore_instances_regexes << Regexp.new(r)
           end
->>>>>>> origin/master
         end
         
         zone_output = options[:zone_output]

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -27,6 +27,7 @@ module SportNginAwsAuditor
 
         ignore_instances_patterns = options[:ignore_instances_patterns].split(', ') if options[:ignore_instances_patterns]
         ignore_instances_regexes = []
+        puts ignore_instances_patterns
         ignore_instances_patterns.each do |r|
           ignore_instances_regexes << Regexp.new(r)
         end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -85,7 +85,7 @@ module SportNginAwsAuditor
             # and size = 't2.small'
             size = my_match[2] if my_match
 
-            n = platform << audit_results.region << ' ' << size
+            n = (platform || "") << (audit_results.region || "") << ' ' << size
             say "#{n} (#{ri.count}) on #{ri.expiration_date}"
           else
             say "#{ri.to_s} (#{ri.count}) on #{ri.expiration_date}"


### PR DESCRIPTION
Description and Impact
----------------------
When the auditor was originally made, we implemented some caching of the instances and reserved instances, so that tons of API calls wouldn't be made over and over again when no changes were in place. However, now we want the auditor to gather fresh data every time we run the auditor, so we don't want any caching in place. This may slow down the results of some of the runs of the auditor, but we prefer that over the caching.

Deploy Plan
-----------
* checkout master
* `op accept-pull 29`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Run the auditor
- [x] Make a change in AWS that will affect the auditor results
- [x] Run the auditor again