### PR TITLE
Adding abilities to audit cross account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ branches:
 
 language: ruby
 rvm:
-  - 2.2
+  - 2.2.5
 cache: bundler
 script: bundle exec rspec

--- a/bin/sport-ngin-aws-auditor
+++ b/bin/sport-ngin-aws-auditor
@@ -18,7 +18,8 @@ flag [:role_name], :desc => 'The name of the role that is giving cross account a
 flag [:arn_id], :desc => 'The identifying digits of the AWS arn if using assume_roles;
                           should be the numerical part of the example:
                           arn:aws:iam::999999999999:role/#{role_name}'
-flag [:region], :desc => 'The region the audit should occur in', :default_value => 'us-east-1'
+flag [:region], :desc => 'The region(s) the audit should occur in; if no region is specified, then the auditor will be run in every
+                          U.S. region. To run multiple regions, the input should be a string like: us-east-1, us-east-2'
 
 program_long_desc """
 DOCUMENTATION

--- a/bin/sport-ngin-aws-auditor
+++ b/bin/sport-ngin-aws-auditor
@@ -11,7 +11,14 @@ version SportNginAwsAuditor::VERSION
 wrap_help_text :verbatim
 
 flag [:config], :desc => 'SportNginAwsAuditor config file path', :default_value => SportNginAwsAuditor::DefaultPaths.config
+flag [:display], :desc => 'The name that should be printed in the output'
 switch [:aws_roles], :desc => 'Use AWS roles instead of an ~/.aws/credentials file'
+switch [:assume_roles], :desc => 'Assume roles to audit cross accounts; should have roles/policies already set up'
+flag [:role_name], :desc => 'The name of the role that is giving cross account access', :default_value => 'CrossAccountAuditorAccess'
+flag [:arn_id], :desc => 'The identifying digits of the AWS arn if using assume_roles;
+                            should be the numerical part of the example:
+                            arn:aws:iam::999999999999:role/#{role_name}'
+flag [:region], :desc => 'The region the audit should occur in', :default_value => 'us-east-1'
 
 program_long_desc """
 DOCUMENTATION

--- a/bin/sport-ngin-aws-auditor
+++ b/bin/sport-ngin-aws-auditor
@@ -16,8 +16,8 @@ switch [:aws_roles], :desc => 'Use AWS roles instead of an ~/.aws/credentials fi
 switch [:assume_roles], :desc => 'Assume roles to audit cross accounts; should have roles/policies already set up'
 flag [:role_name], :desc => 'The name of the role that is giving cross account access', :default_value => 'CrossAccountAuditorAccess'
 flag [:arn_id], :desc => 'The identifying digits of the AWS arn if using assume_roles;
-                            should be the numerical part of the example:
-                            arn:aws:iam::999999999999:role/#{role_name}'
+                          should be the numerical part of the example:
+                          arn:aws:iam::999999999999:role/#{role_name}'
 flag [:region], :desc => 'The region the audit should occur in', :default_value => 'us-east-1'
 
 program_long_desc """

--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -1,15 +1,27 @@
 require_relative './instance_helper'
+require_relative './convenience_wrappers'
 
 module SportNginAwsAuditor
   class AuditData
+    extend EC2Wrapper
+    extend RDSWrapper
+    extend CacheWrapper
 
-    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region, :ignore_instances_regexes
+    attr_accessor :data, :retired_tags, :retired_ris, :selected_audit_type, :klass, :tag_name, :region, :ignore_instances_regexes, :client
     def initialize(info)
       self.selected_audit_type = (!info[:instances] && !info[:reserved]) ? "all" : (info[:instances] ? "instances" : "reserved")
       self.klass = SportNginAwsAuditor.const_get(info[:class])
       self.tag_name = info[:tag_name]
       self.ignore_instances_regexes = info[:regexes]
       self.region = info[:region].match(/(\w{2}-\w{4,})/)[0] if info[:region].match(/(\w{2}-\w{4,})/)
+      
+      if info[:class] == "EC2Instance"
+        self.client = EC2Wrapper.ec2(info[:region])
+      elsif info[:class] == "RDSInstance"
+        self.client = RDSWrapper.rds(info[:region])
+      elsif info[:class] == "CacheInstance"
+        self.client = CacheWrapper.cache(info[:region])
+      end
     end
 
     def instances?
@@ -29,7 +41,7 @@ module SportNginAwsAuditor
         instance_hash, retired_tags = gather_instances_data
         retired_ris = nil
       elsif reserved?
-        instance_hash = self.klass.instance_count_hash(self.klass.get_reserved_instances)
+        instance_hash = self.klass.instance_count_hash(self.klass.get_reserved_instances(self.client))
         retired_tags, retired_ris = nil
       elsif all?
         instance_hash, retired_tags, retired_ris = gather_all_data
@@ -46,7 +58,7 @@ module SportNginAwsAuditor
     end
 
     def gather_instances_data
-      instances = self.klass.get_instances(tag_name)
+      instances = self.klass.get_instances(self.client, tag_name)
       retired_tags = self.klass.get_retired_tags(instances)
       instances_with_tag = self.klass.filter_instances_with_tags(instances)
       instances_without_tag = self.klass.filter_instances_without_tags(instances)
@@ -57,10 +69,10 @@ module SportNginAwsAuditor
     end
 
     def gather_all_data
-      instances = self.klass.get_instances(tag_name)
+      instances = self.klass.get_instances(self.client, tag_name)
       retired_tags = self.klass.get_retired_tags(instances)
-      instance_hash = self.klass.compare(instances, ignore_instances_regexes)
-      retired_ris = self.klass.get_recent_retired_reserved_instances
+      instance_hash = self.klass.compare(instances, ignore_instances_regexes, self.client)
+      retired_ris = self.klass.get_recent_retired_reserved_instances(self.client)
 
       return instance_hash, retired_tags, retired_ris
     end

--- a/lib/sport_ngin_aws_auditor/aws.rb
+++ b/lib/sport_ngin_aws_auditor/aws.rb
@@ -8,48 +8,48 @@ module SportNginAwsAuditor
   end
 
   class AWSSDK
-    def self.authenticate_with_iam(environment, region)
+    def self.authenticate_with_iam(environment)
       shared_credentials = Aws::SharedCredentials.new(profile_name: environment)
-      update_aws_config({region: region, credentials: shared_credentials})
+      update_aws_config({region: 'us-east-1', credentials: shared_credentials})
       iam = Aws::IAM::Client.new
 
       # this will be an array of 0 or 1 because iam.list_mfa_devices.mfa_devices will only return 0 or 1 device per user;
       # if user doesn't have MFA enabled, then this loop won't even execute
       iam.list_mfa_devices.mfa_devices.each do |mfadevice|
-        authenticate_with_mfa(mfadevice, shared_credentials, region)
+        authenticate_with_mfa(mfadevice, shared_credentials)
       end
     end
 
-    def self.authenticate_with_mfa(mfadevice, shared_credentials, region)
+    def self.authenticate_with_mfa(mfadevice, shared_credentials)
       mfa_serial_number = mfadevice.serial_number
       mfa_token = Output.ask("Enter MFA token: "){ |q|  q.validate = /^\d{6}$/ }
       session_credentials_hash = get_session(mfa_token,
                                              mfa_serial_number,
                                              shared_credentials.credentials.access_key_id,
-                                             shared_credentials.credentials.secret_access_key,
-                                             region).credentials
+                                             shared_credentials.credentials.secret_access_key).credentials
 
       session_credentials = Aws::Credentials.new(session_credentials_hash.access_key_id,
                                                  session_credentials_hash.secret_access_key,
                                                  session_credentials_hash.session_token)
-      update_aws_config({region: region, credentials: session_credentials})
+      update_aws_config({region: 'us-east-1', credentials: session_credentials})
     end
 
-    def self.authenticate_with_assumed_roles(environment, arn_id, role_name, region)
-      sts = Aws::STS::Client.new(profile: environment, region: region)
+    def self.authenticate_with_assumed_roles(environment, arn_id, role_name)
+      sts = Aws::STS::Client.new(profile: environment, region: 'us-east-1')
       role_arn = "arn:aws:iam::#{arn_id}:role/#{role_name}"
+      session_name = "auditor#{Time.now.to_i}"
       assumed_role_credentials = Aws::AssumeRoleCredentials.new(client: sts,
                                                                 role_arn: role_arn,
-                                                                role_session_name: 'auditor')
-      update_aws_config({region: region, credentials: assumed_role_credentials})
+                                                                role_session_name: session_name)
+      update_aws_config({region: 'us-east-1', credentials: assumed_role_credentials})
       return assumed_role_credentials
     end
 
-    def self.get_session(mfa_token, mfa_serial_number, access_key_id, secret_access_key, region)
+    def self.get_session(mfa_token, mfa_serial_number, access_key_id, secret_access_key)
       return @session if @session
       sts = Aws::STS::Client.new(access_key_id: access_key_id,
                                  secret_access_key: secret_access_key,
-                                 region: region)
+                                 region: 'us-east-1')
       @session = sts.get_session_token(duration_seconds: 3600,
                                        serial_number: mfa_serial_number,
                                        token_code: mfa_token)

--- a/lib/sport_ngin_aws_auditor/aws.rb
+++ b/lib/sport_ngin_aws_auditor/aws.rb
@@ -34,11 +34,10 @@ module SportNginAwsAuditor
       update_aws_config({region: 'us-east-1', credentials: session_credentials})
     end
 
-    def self.authenticate_with_assumed_roles(environment, arn_id, role_name)
-      sts = Aws::STS::Client.new(profile: environment, region: 'us-east-1')
+    def self.authenticate_with_assumed_roles(environment, arn_id, role_name, sts_client)
       role_arn = "arn:aws:iam::#{arn_id}:role/#{role_name}"
       session_name = "auditor#{Time.now.to_i}"
-      assumed_role_credentials = Aws::AssumeRoleCredentials.new(client: sts,
+      assumed_role_credentials = Aws::AssumeRoleCredentials.new(client: sts_client,
                                                                 role_arn: role_arn,
                                                                 role_session_name: session_name)
       update_aws_config({region: 'us-east-1', credentials: assumed_role_credentials})
@@ -53,7 +52,7 @@ module SportNginAwsAuditor
       @session = sts.get_session_token(duration_seconds: 3600,
                                        serial_number: mfa_serial_number,
                                        token_code: mfa_token)
-    end
+    end    
 
     def self.update_aws_config(options)
         Aws.config.update(options)

--- a/lib/sport_ngin_aws_auditor/aws.rb
+++ b/lib/sport_ngin_aws_auditor/aws.rb
@@ -8,14 +8,14 @@ module SportNginAwsAuditor
   end
 
   class AWSSDK
-    def self.authenticate(environment, region)
+    def self.authenticate_with_iam(environment, region)
       shared_credentials = Aws::SharedCredentials.new(profile_name: environment)
-      Aws.config.update({region: region, credentials: shared_credentials})
+      update_aws_config({region: region, credentials: shared_credentials})
 
       iam = Aws::IAM::Client.new
 
-       # this will be an array of 0 or 1 because iam.list_mfa_devices.mfa_devices will only return 0 or 1 device per user;
-       # if user doesn't have MFA enabled, then this loop won't even execute
+      # this will be an array of 0 or 1 because iam.list_mfa_devices.mfa_devices will only return 0 or 1 device per user;
+      # if user doesn't have MFA enabled, then this loop won't even execute
       iam.list_mfa_devices.mfa_devices.each do |mfadevice|
         mfa_serial_number = mfadevice.serial_number
         mfa_token = Output.ask("Enter MFA token: "){ |q|  q.validate = /^\d{6}$/ }
@@ -28,7 +28,7 @@ module SportNginAwsAuditor
         session_credentials = Aws::Credentials.new(session_credentials_hash.access_key_id,
                                                    session_credentials_hash.secret_access_key,
                                                    session_credentials_hash.session_token)
-        Aws.config.update({region: region, credentials: session_credentials})
+        update_aws_config({region: region, credentials: session_credentials})
       end
     end
 
@@ -42,15 +42,18 @@ module SportNginAwsAuditor
                                        token_code: mfa_token)
     end
 
-    def self.authenticate_with_roles(environment, region)
-        Aws.config.update({region: region})
+    def self.update_aws_config(options)
+        Aws.config.update(options)
     end
 
-    def self.authenticate_for_multiple_accounts(environment, arn_id, role_name, region)
-      sts = Aws::STS::Client.new(:profile => environment, :region => region)
-      creds = Aws::AssumeRoleCredentials.new(:client => sts, :role_arn => "arn:aws:iam::#{arn_id}:role/#{role_name}", :role_session_name => 'auditor')
-      Aws.config.update({region: region, credentials: creds})
-      return creds
+    def self.authenticate_with_assumed_roles(environment, arn_id, role_name, region)
+      sts = Aws::STS::Client.new(profile: environment, region: region)
+      role_arn = "arn:aws:iam::#{arn_id}:role/#{role_name}"
+      assumed_role_credentials = Aws::AssumeRoleCredentials.new(client: sts,
+                                                                role_arn: role_arn,
+                                                                role_session_name: 'auditor')
+      update_aws_config({region: region, credentials: assumed_role_credentials})
+      return assumed_role_credentials
     end
   end
 end

--- a/lib/sport_ngin_aws_auditor/cache_instance.rb
+++ b/lib/sport_ngin_aws_auditor/cache_instance.rb
@@ -7,23 +7,23 @@ module SportNginAwsAuditor
     extend AWSWrapper
 
     class << self
-      def get_instances(tag_name=nil)
+      def get_instances(client, tag_name=nil)
         account_id = get_account_id
-        cache.describe_cache_clusters.cache_clusters.map do |instance|
+        client.describe_cache_clusters.cache_clusters.map do |instance|
           next unless instance.cache_cluster_status.to_s == 'available'
-          new(instance, account_id, tag_name, cache)
+          new(instance, account_id, tag_name, client)
         end.compact
       end
 
-      def get_reserved_instances
-        cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
+      def get_reserved_instances(client)
+        client.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
           next unless instance.state.to_s == 'active'
           new(instance)
         end.compact
       end
 
-      def get_retired_reserved_instances
-        cache.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
+      def get_retired_reserved_instances(client)
+        client.describe_reserved_cache_nodes.reserved_cache_nodes.map do |instance|
           next unless instance.state == 'retired'
           new(instance)
         end.compact
@@ -31,7 +31,7 @@ module SportNginAwsAuditor
     end
 
     attr_accessor :id, :name, :instance_type, :scope, :engine, :count, :tag_value, :tag_reason, :expiration_date, :availability_zone
-    def initialize(cache_instance, account_id=nil, tag_name=nil, cache=nil)
+    def initialize(cache_instance, account_id=nil, tag_name=nil, client=nil)
       if cache_instance.class.to_s == "Aws::ElastiCache::Types::ReservedCacheNode"
         self.id = cache_instance.reserved_cache_node_id
         self.name = cache_instance.reserved_cache_node_id
@@ -56,7 +56,7 @@ module SportNginAwsAuditor
           arn = "arn:aws:elasticache:#{region}:#{account_id}:cluster:#{self.id}"
 
           # go through to see if the tag we're looking for is one of them
-          cache.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
+          client.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
             elsif tag.key == 'no-reserved-instance-reason'

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -1,4 +1,5 @@
 require_relative './aws'
+require 'aws-sdk'
 require_relative './google'
 
 module SportNginAwsAuditor
@@ -12,7 +13,7 @@ module SportNginAwsAuditor
         @assume_role_creds = SportNginAwsAuditor::AWSSDK.authenticate_with_assumed_roles(environment,
                                                                                          global_options[:arn_id],
                                                                                          global_options[:role_name],
-                                                                                         get_sts_client)
+                                                                                         get_sts_client(environment))
       else
         SportNginAwsAuditor::AWSSDK.authenticate_with_iam(environment)
       end
@@ -22,7 +23,7 @@ module SportNginAwsAuditor
       Aws::STS::Client.new.get_caller_identity.account
     end
 
-    def get_sts_client
+    def get_sts_client(environment)
       @sts_client ||= Aws::STS::Client.new(profile: environment, region: 'us-east-1')
     end
   end

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -8,6 +8,7 @@ module SportNginAwsAuditor
     attr_accessor :aws, :account_id
 
     def aws(environment, global_options)
+      return @aws if @aws
       if global_options[:aws_roles]
         SportNginAwsAuditor::AWSSDK.update_aws_config({region: global_options[:region]})
       elsif global_options[:assume_roles]

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -9,14 +9,13 @@ module SportNginAwsAuditor
 
     def aws(environment, global_options)
       if global_options[:aws_roles]
-        SportNginAwsAuditor::AWSSDK.update_aws_config({region: global_options[:region]})
+        SportNginAwsAuditor::AWSSDK.update_aws_config({region: 'us-east-1'})
       elsif global_options[:assume_roles]
         @assume_role_creds = SportNginAwsAuditor::AWSSDK.authenticate_with_assumed_roles(environment,
                                                                                          global_options[:arn_id],
-                                                                                         global_options[:role_name],
-                                                                                         global_options[:region])
+                                                                                         global_options[:role_name])
       else
-        SportNginAwsAuditor::AWSSDK.authenticate_with_iam(environment, global_options[:region])
+        SportNginAwsAuditor::AWSSDK.authenticate_with_iam(environment)
       end
     end
 
@@ -26,12 +25,13 @@ module SportNginAwsAuditor
   end
 
   module EC2Wrapper
-    attr_accessor :ec2
-
-    def ec2
-      return @ec2 if @ec2
-      if @assume_role_creds
+    def self.ec2(region=nil)
+      if @assume_role_creds && region 
+        @ec2 = Aws::EC2::Client.new(credentials: @assume_role_creds, region: region)
+      elsif @assume_role_creds && !region
         @ec2 = Aws::EC2::Client.new(credentials: @assume_role_creds)
+      elsif @assume_role_creds.nil? && region
+        @ec2 = Aws::EC2::Client.new(region: region)
       else
         @ec2 = Aws::EC2::Client.new
       end
@@ -52,12 +52,13 @@ module SportNginAwsAuditor
   end
 
   module RDSWrapper
-    attr_accessor :rds
-
-    def rds
-      return @rds if @rds
-      if @assume_role_creds
+    def self.rds(region=nil)
+      if @assume_role_creds && region
+        @rds = Aws::RDS::Client.new(credentials: @assume_role_creds, region: region)
+      elsif @assume_role_creds && !region
         @rds = Aws::RDS::Client.new(credentials: @assume_role_creds)
+      elsif @assume_role_creds.nil? && region
+        @rds = Aws::RDS::Client.new(region: region)
       else
         @rds = Aws::RDS::Client.new
       end
@@ -65,12 +66,13 @@ module SportNginAwsAuditor
   end
     
   module CacheWrapper
-    attr_accessor :cache
-
-    def cache
-      return @cache if @cache
-      if @assume_role_creds
+    def self.cache(region=nil)
+      if @assume_role_creds && region
+        @cache = Aws::ElastiCache::Client.new(credentials: @assume_role_creds, region: region)
+      elsif @assume_role_creds && !region
         @cache = Aws::ElastiCache::Client.new(credentials: @assume_role_creds)
+      elsif @assume_role_creds.nil? && region
+        @cache = Aws::ElastiCache::Client.new(region: region)
       else
         @cache = Aws::ElastiCache::Client.new
       end

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -5,8 +5,6 @@ module SportNginAwsAuditor
   attr_accessor :assume_role_creds
 
   module AWSWrapper
-    attr_accessor :aws, :account_id
-
     def aws(environment, global_options)
       if global_options[:aws_roles]
         SportNginAwsAuditor::AWSSDK.update_aws_config({region: 'us-east-1'})
@@ -20,7 +18,7 @@ module SportNginAwsAuditor
     end
 
     def get_account_id
-      @account_id ||= Aws::STS::Client.new.get_caller_identity.account
+      Aws::STS::Client.new.get_caller_identity.account
     end
   end
 

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -8,7 +8,6 @@ module SportNginAwsAuditor
     attr_accessor :aws, :account_id
 
     def aws(environment, global_options)
-      return @aws if @aws
       if global_options[:aws_roles]
         SportNginAwsAuditor::AWSSDK.update_aws_config({region: global_options[:region]})
       elsif global_options[:assume_roles]

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -11,7 +11,8 @@ module SportNginAwsAuditor
       elsif global_options[:assume_roles]
         @assume_role_creds = SportNginAwsAuditor::AWSSDK.authenticate_with_assumed_roles(environment,
                                                                                          global_options[:arn_id],
-                                                                                         global_options[:role_name])
+                                                                                         global_options[:role_name],
+                                                                                         get_sts_client)
       else
         SportNginAwsAuditor::AWSSDK.authenticate_with_iam(environment)
       end
@@ -19,6 +20,10 @@ module SportNginAwsAuditor
 
     def get_account_id
       Aws::STS::Client.new.get_caller_identity.account
+    end
+
+    def get_sts_client
+      @sts_client ||= Aws::STS::Client.new(profile: environment, region: 'us-east-1')
     end
   end
 

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -9,14 +9,14 @@ module SportNginAwsAuditor
 
     def aws(environment, global_options)
       if global_options[:aws_roles]
-        SportNginAwsAuditor::AWSSDK.authenticate_with_roles(environment, global_options[:region])
+        SportNginAwsAuditor::AWSSDK.update_aws_config({region: global_options[:region]})
       elsif global_options[:assume_roles]
-        @assume_role_creds = SportNginAwsAuditor::AWSSDK.authenticate_for_multiple_accounts(environment,
-                                                                                            global_options[:arn_id],
-                                                                                            global_options[:role_name],
-                                                                                            global_options[:region])
+        @assume_role_creds = SportNginAwsAuditor::AWSSDK.authenticate_with_assumed_roles(environment,
+                                                                                         global_options[:arn_id],
+                                                                                         global_options[:role_name],
+                                                                                         global_options[:region])
       else
-        SportNginAwsAuditor::AWSSDK.authenticate(environment, global_options[:region])
+        SportNginAwsAuditor::AWSSDK.authenticate_with_iam(environment, global_options[:region])
       end
     end
 

--- a/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
+++ b/lib/sport_ngin_aws_auditor/convenience_wrappers.rb
@@ -26,6 +26,10 @@ module SportNginAwsAuditor
     def get_sts_client(environment)
       @sts_client ||= Aws::STS::Client.new(profile: environment, region: 'us-east-1')
     end
+
+    def reset_credentials
+      SportNginAwsAuditor::AWSSDK.update_aws_config({credentials: Aws::InstanceProfileCredentials.new})
+    end
   end
 
   module EC2Wrapper

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -6,25 +6,25 @@ module SportNginAwsAuditor
     extend EC2Wrapper
 
     class << self
-      def get_instances(tag_name=nil)
-        instances = ec2.describe_instances.reservations.map do |reservation|
+      def get_instances(client, tag_name=nil)
+        instances = client.describe_instances.reservations.map do |reservation|
           reservation.instances.map do |instance|
             next unless instance.state.name == 'running'
             new(instance, tag_name)
           end.compact
         end.flatten.compact
-        get_more_info(instances)
+        get_more_info(instances, client)
       end
 
-      def get_reserved_instances
-        ec2.describe_reserved_instances.reserved_instances.map do |instance|
+      def get_reserved_instances(client)
+        client.describe_reserved_instances.reserved_instances.map do |instance|
           next unless instance.state == 'active'
           new(instance, nil, instance.instance_count)
         end.compact
       end
 
-      def get_retired_reserved_instances
-        ec2.describe_reserved_instances.reserved_instances.map do |instance|
+      def get_retired_reserved_instances(client)
+        client.describe_reserved_instances.reserved_instances.map do |instance|
           next unless instance.state == 'retired'
           new(instance, nil, instance.instance_count)
         end.compact
@@ -44,9 +44,9 @@ module SportNginAwsAuditor
         buckets.sort_by{|k,v| k }
       end
 
-      def get_more_info(instances)
+      def get_more_info(instances, client)
         instances.each do |instance|
-          tags = ec2.describe_tags(:filters => [{:name => "resource-id", :values => [instance.id]}]).tags
+          tags = client.describe_tags(:filters => [{:name => "resource-id", :values => [instance.id]}]).tags
           tags = Hash[tags.map { |tag| [tag[:key], tag[:value]]}.compact]
           instance.name = tags["Name"]
           instance.stack_name = tags["opsworks:stack"]

--- a/lib/sport_ngin_aws_auditor/ec2_instance.rb
+++ b/lib/sport_ngin_aws_auditor/ec2_instance.rb
@@ -30,9 +30,9 @@ module SportNginAwsAuditor
         end.compact
       end
 
-      def bucketize
+      def bucketize(client)
         buckets = {}
-        get_instances.map do |instance|
+        get_instances(client).map do |instance|
           name = instance.stack_name || instance.name
           if name
             buckets[name] = [] unless buckets.has_key? name

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -5,11 +5,11 @@ module SportNginAwsAuditor
   module InstanceHelper
 
     def instance_hash
-      Hash[get_instances.map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
+      Hash[get_instances(client).map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 
     def reserved_instance_hash
-      Hash[get_reserved_instances.map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
+      Hash[get_reserved_instances(client).map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 
     #################### ADDING DATA TO HASH ####################
@@ -102,8 +102,8 @@ module SportNginAwsAuditor
       return ignored_instances, instances_with_tag, instance_hash
     end
 
-    def sort_through_RIs
-      ris = get_reserved_instances
+    def sort_through_RIs(client)
+      ris = get_reserved_instances(client)
       ris_availability = filter_ris_availability_zone(ris)
       ris_region = filter_ris_region_based(ris)
       ris_hash = instance_count_hash(ris_availability)
@@ -127,9 +127,9 @@ module SportNginAwsAuditor
       return differences
     end
 
-    def compare(instances, ignore_instances_regexes)
+    def compare(instances, ignore_instances_regexes, client)
       ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances, ignore_instances_regexes)
-      ris_region, ris_hash = sort_through_RIs
+      ris_region, ris_hash = sort_through_RIs(client)
       differences = measure_differences(instance_hash, ris_hash)
       add_additional_data(ris_region, instances_with_tag, ignored_instances, differences)
       differences
@@ -177,8 +177,8 @@ module SportNginAwsAuditor
 
     # this gets all retired reserved instances and filters out only the ones that have expired
     # within the past week
-    def get_recent_retired_reserved_instances
-      get_retired_reserved_instances.select do |ri|
+    def get_recent_retired_reserved_instances(client)
+      get_retired_reserved_instances(client).select do |ri|
         ri.expiration_date > (Time.now - 604800)
       end
     end

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -4,11 +4,11 @@ require_relative './audit_data'
 module SportNginAwsAuditor
   module InstanceHelper
 
-    def instance_hash
+    def instance_hash(client)
       Hash[get_instances(client).map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 
-    def reserved_instance_hash
+    def reserved_instance_hash(client)
       Hash[get_reserved_instances(client).map { |instance| instance.nil? ? next : [instance.id, instance]}.compact]
     end
 

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -7,23 +7,23 @@ module SportNginAwsAuditor
     extend AWSWrapper
 
     class << self
-      def get_instances(tag_name=nil)
+      def get_instances(client, tag_name=nil)
         account_id = get_account_id
-        rds.describe_db_instances.db_instances.map do |instance|
+        client.describe_db_instances.db_instances.map do |instance|
           next unless instance.db_instance_status.to_s == 'available'
-          new(instance, account_id, tag_name, rds)
+          new(instance, account_id, tag_name, client)
         end.compact
       end
 
-      def get_reserved_instances
-        rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
+      def get_reserved_instances(client)
+        client.describe_reserved_db_instances.reserved_db_instances.map do |instance|
           next unless instance.state.to_s == 'active'
           new(instance)
         end.compact
       end
 
-      def get_retired_reserved_instances
-        rds.describe_reserved_db_instances.reserved_db_instances.map do |instance|
+      def get_retired_reserved_instances(client)
+        client.describe_reserved_db_instances.reserved_db_instances.map do |instance|
           next unless instance.state == 'retired'
           new(instance)
         end.compact
@@ -31,7 +31,7 @@ module SportNginAwsAuditor
     end
 
     attr_accessor :id, :name, :multi_az, :scope, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
-    def initialize(rds_instance, account_id=nil, tag_name=nil, rds=nil)
+    def initialize(rds_instance, account_id=nil, tag_name=nil, client=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
         self.scope = nil
@@ -55,7 +55,7 @@ module SportNginAwsAuditor
           arn = "arn:aws:rds:#{region}:#{account_id}:db:#{self.id}"
 
            # go through to see if the tag we're looking for is one of them
-          rds.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
+          client.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
               self.tag_value = tag.value
             elsif tag.key == 'no-reserved-instance-reason'

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -50,7 +50,7 @@ module SportNginAwsAuditor
           audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regexes)
           audit_results.gather_data
           output_options = {:slack => slack, :class_type => c.first,
-                            :environment => display_name, :zone_output => zone_output}
+                            :display_name => display_name, :zone_output => zone_output}
           print_data(audit_results, output_options) if (c.last || no_selection)
         end
       end
@@ -74,7 +74,7 @@ module SportNginAwsAuditor
 
       def self.say_retired_ris(audit_results, output_options)
         retired_ris = audit_results.retired_ris
-        say "The following reserved #{output_options[:class_type]}Instances have recently expired in #{output_options[:environment]}:"
+        say "The following reserved #{output_options[:class_type]}Instances have recently expired in #{output_options[:display_name]}:"
         retired_ris.each do |ri|
           if ri.availability_zone.nil?
             # if ri.to_s = 'Linux VPC  t2.small'...
@@ -96,7 +96,7 @@ module SportNginAwsAuditor
 
       def self.say_retired_tags(audit_results, output_options)
         retired_tags = audit_results.retired_tags
-        say "The following #{output_options[:class_type]}Instance tags have recently expired in #{output_options[:environment]}:"
+        say "The following #{output_options[:class_type]}Instance tags have recently expired in #{output_options[:display_name]}:"
         retired_tags.each do |tag|
           if tag.reason
             say "#{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because #{tag.reason}"
@@ -153,7 +153,7 @@ module SportNginAwsAuditor
       end
 
       def self.print_discrepancies(discrepancy_array, output_options)
-        title = "Some #{output_options[:class_type]} discrepancies for #{output_options[:environment]} exist:\n"
+        title = "Some #{output_options[:class_type]} discrepancies for #{output_options[:display_name]} exist:\n"
         slack_instances = NotifySlack.new(title, options[:config_json])
 
         discrepancy_array.each do |discrepancy|
@@ -171,7 +171,7 @@ module SportNginAwsAuditor
       end
 
       def self.print_tagged(tagged_ignored_array, output_options)
-        title = "There are currently some tagged or ignored #{output_options[:class_type]}s in #{output_options[:environment]}:\n"
+        title = "There are currently some tagged or ignored #{output_options[:class_type]}s in #{output_options[:display_name]}:\n"
         slack_instances = NotifySlack.new(title, options[:config_json])
 
         tagged_ignored_array.each do |tagged_or_ignored|
@@ -197,7 +197,7 @@ module SportNginAwsAuditor
 
       def self.print_retired_ris(audit_results, output_options)
         retired_ris = audit_results.retired_ris
-        message = "The following reserved #{output_options[:class_type]}s have recently expired in #{output_options[:environment]}:\n"
+        message = "The following reserved #{output_options[:class_type]}s have recently expired in #{output_options[:display_name]}:\n"
 
         retired_ris.each do |ri|
           if ri.availability_zone.nil?
@@ -226,7 +226,7 @@ module SportNginAwsAuditor
 
       def self.print_retired_tags(audit_results, output_options)
         retired_tags = audit_results.retired_tags
-        message = "The following #{output_options[:class_type]} tags have recently expired in #{output_options[:environment]}:\n"
+        message = "The following #{output_options[:class_type]} tags have recently expired in #{output_options[:display_name]}:\n"
 
         retired_tags.each do |tag|
           if tag.reason

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -44,7 +44,7 @@ module SportNginAwsAuditor
           print "Gathering info, please wait..."; print "\r"
         else
           puts "Condensed results from this audit will print into Slack instead of directly to an output."
-          NotifySlack.new("AWS AUDIT FOR #{display_name} IN REGION *_#{global_options[:region]}_*\n\n\n\n", options[:config_json]).perform
+          NotifySlack.new("_AWS AUDIT FOR #{display_name} IN REGION *_#{global_options[:region]}_*_", options[:config_json]).perform
         end
 
         cycle.each do |c|

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -17,7 +17,9 @@ module SportNginAwsAuditor
       #################### EXECUTION ####################
 
       def self.execute(environment, options, global_options)
+        puts "About to  configure clients"
         aws(environment, global_options)
+        puts "Clients configured"
         collect_options(options, global_options)
         print_title
         @regions.each { |region| audit_region(region) }

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -44,6 +44,9 @@ module SportNginAwsAuditor
           print "Gathering info, please wait..."; print "\r"
         else
           puts "Condensed results from this audit will print into Slack instead of directly to an output."
+          NotifySlack.new("******************************************************************\n
+                           AWS AUDIT FOR #{display_name} IN REGION #{global_options[:region]}\n
+                           ******************************************************************\n", options[:config_json]).perform
         end
 
         cycle.each do |c|

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -48,7 +48,9 @@ module SportNginAwsAuditor
         end
 
         cycle.each do |c|
-          audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regexes)
+          audit_results = AuditData.new({:instances => options[:instances], :reserved => options[:reserved],
+                                         :class => c.first, :tag_name => tag_name,
+                                         :regexes => ignore_instances_regexes, :region => global_options[:region]})
           audit_results.gather_data
           output_options = {:slack => slack, :class_type => c.first,
                             :display_name => display_name, :zone_output => zone_output}
@@ -57,6 +59,7 @@ module SportNginAwsAuditor
       end
 
       def self.print_data(audit_results, output_options)
+        return if audit_results.data.empty?
         audit_results.data.sort_by! { |instance| [instance.category, instance.type] }
 
         if output_options[:slack]

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -37,9 +37,9 @@ module SportNginAwsAuditor
         
         zone_output = options[:zone_output]
 
-        cycle = [["EC2Instance", options[:ec2]],
-                 ["RDSInstance", options[:rds]],
-                 ["CacheInstance", options[:cache]]]
+        instance_types = [["EC2Instance", options[:ec2]],
+                          ["RDSInstance", options[:rds]],
+                          ["CacheInstance", options[:cache]]]
 
         regions = (global_options[:region].split(', ') if global_options[:region]) || gather_regions
 
@@ -50,19 +50,19 @@ module SportNginAwsAuditor
         end
 
         regions.each do |r|
-          cycle.each do |c|
+          instance_types.each do |t|
             audit_results = AuditData.new({:instances => options[:instances], :reserved => options[:reserved],
-                                           :class => c.first, :tag_name => tag_name,
+                                           :class => t.first, :tag_name => tag_name,
                                            :regexes => ignore_instances_regexes, :region => r})
             audit_results.gather_data
 
             unless audit_results.data.empty?
-              puts "AWS AUDIT FOR #{display_name} IN REGION #{r} for #{c.first}s".colorize(:white).on_blue.underline if !slack
-              NotifySlack.new("_AWS AUDIT FOR #{display_name} IN REGION *_#{r}_* for *_#{c.first}s_*_", options[:config_json]).perform if slack
+              puts "AWS AUDIT FOR #{display_name} IN REGION #{r} for #{t.first}s".colorize(:white).on_blue.underline if !slack
+              NotifySlack.new("_AWS AUDIT FOR #{display_name} IN REGION *_#{r}_* for *_#{t.first}s_*_", options[:config_json]).perform if slack
 
-              output_options = {:slack => slack, :class => c.first,
+              output_options = {:slack => slack, :class => t.first,
                                 :display_name => display_name, :zone_output => zone_output}
-              print_data(audit_results, output_options) if (c.last || no_selection)
+              print_data(audit_results, output_options) if (t.last || no_selection)
             end
           end
         end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -44,9 +44,7 @@ module SportNginAwsAuditor
           print "Gathering info, please wait..."; print "\r"
         else
           puts "Condensed results from this audit will print into Slack instead of directly to an output."
-          NotifySlack.new("******************************************************************\n
-                           AWS AUDIT FOR #{display_name} IN REGION #{global_options[:region]}\n
-                           ******************************************************************\n", options[:config_json]).perform
+          NotifySlack.new("********AWS AUDIT FOR #{display_name} IN REGION *_#{global_options[:region]}_*********\n\n\n\n", options[:config_json]).perform
         end
 
         cycle.each do |c|

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -13,9 +13,10 @@ module SportNginAwsAuditor
         attr_accessor :options
       end
 
-      def self.execute(environment, options=nil, global_options=nil)
-        aws(environment, global_options[:aws_roles])
+      def self.execute(environment, options, global_options)
+        aws(environment, global_options)
         @options = options
+        display_name = global_options[:display] || environment
         slack = options[:slack]
         no_selection = !(options[:ec2] || options[:rds] || options[:cache])
 
@@ -49,7 +50,7 @@ module SportNginAwsAuditor
           audit_results = AuditData.new(options[:instances], options[:reserved], c.first, tag_name, ignore_instances_regexes)
           audit_results.gather_data
           output_options = {:slack => slack, :class_type => c.first,
-                            :environment => environment, :zone_output => zone_output}
+                            :environment => display_name, :zone_output => zone_output}
           print_data(audit_results, output_options) if (c.last || no_selection)
         end
       end

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -44,7 +44,7 @@ module SportNginAwsAuditor
           print "Gathering info, please wait..."; print "\r"
         else
           puts "Condensed results from this audit will print into Slack instead of directly to an output."
-          NotifySlack.new("********AWS AUDIT FOR #{display_name} IN REGION *_#{global_options[:region]}_*********\n\n\n\n", options[:config_json]).perform
+          NotifySlack.new("AWS AUDIT FOR #{display_name} IN REGION *_#{global_options[:region]}_*\n\n\n\n", options[:config_json]).perform
         end
 
         cycle.each do |c|

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -17,9 +17,7 @@ module SportNginAwsAuditor
       #################### EXECUTION ####################
 
       def self.execute(environment, options, global_options)
-        puts "About to  configure clients"
         aws(environment, global_options)
-        puts "Clients configured"
         collect_options(options, global_options)
         print_title
         @regions.each { |region| audit_region(region) }

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -21,6 +21,7 @@ module SportNginAwsAuditor
         collect_options(environment, options, global_options)
         print_title
         @regions.each { |region| audit_region(region) }
+        reset_credentials
       end
 
       def self.audit_region(region)

--- a/lib/sport_ngin_aws_auditor/scripts/inspect.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/inspect.rb
@@ -3,19 +3,32 @@ module SportNginAwsAuditor
     class Inspect
       extend AWSWrapper
       extend OpsWorksWrapper
+      extend EC2Wrapper
+      extend RDSWrapper
+      extend CacheWrapper
 
       def self.execute(environment, options=nil, global_options=nil)
-        aws(environment, global_options[:aws_roles])
+        aws(environment, global_options)
+        region = (global_options[:region].split(', ') if global_options[:region]) || 'us-east-1'
         no_selection = options.values.uniq == [false]
-        output("EC2Instance") if options[:ec2] || no_selection
-        output("RDSInstance") if options[:rds] || no_selection 
-        output("CacheInstance") if options[:cache] || no_selection
+        output("EC2Instance", region) if options[:ec2] || no_selection
+        output("RDSInstance", region) if options[:rds] || no_selection
+        output("CacheInstance", region) if options[:cache] || no_selection
       end
 
-      def self.output(class_type)
+      def self.output(class_type, region)
         klass = SportNginAwsAuditor.const_get(class_type)
+
+        if class_type == "EC2Instance"
+          client = EC2Wrapper.ec2(region)
+        elsif class_type == "RDSInstance"
+          client = RDSWrapper.rds(region)
+        elsif class_type == "CacheInstance"
+          client = CacheWrapper.cache(region)
+        end
+
         print "Gathering info, please wait..."; print "\r"
-        instances = class_type == "EC2Instance" ? klass.bucketize : klass.instance_hash
+        instances = class_type == "EC2Instance" ? klass.bucketize(client) : klass.instance_hash(client)
         say "<%= color('#{header(class_type)}', :white) %>"
         instances.each do |key, value|
           pretty_print(key, klass.instance_count_hash(Array(value)))

--- a/lib/sport_ngin_aws_auditor/scripts/inspect.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/inspect.rb
@@ -49,7 +49,7 @@ module SportNginAwsAuditor
         puts "======================================="
         puts "#{title}"
         puts "======================================="
-        body.each{ |key, value| say "<%= color('#{key}: #{value}', :white) %>" }
+        body.each{ |key, value| say "<%= color('#{key}: #{value[:count]}', :white) %>" }
         puts "\n"
       end
     end

--- a/spec/sport_ngin_aws_auditor/audit_data_spec.rb
+++ b/spec/sport_ngin_aws_auditor/audit_data_spec.rb
@@ -28,75 +28,94 @@ module SportNginAwsAuditor
 
     context '#initialization' do
       it 'should gather instance data' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather reserved instance data' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => true, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.selected_audit_type).to eq("reserved")
       end
 
       it 'should by default gather instance data' do
-        audit_results = AuditData.new(true, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => true, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.selected_audit_type).to eq("instances")
       end
 
       it 'should gather all data to compare' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.selected_audit_type).to eq("all")
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.klass).to eq(SportNginAwsAuditor::EC2Instance)
       end
 
       it 'should use EC2Instance class' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.tag_name).to eq("no-reserved-instance")
+      end
+
+      it 'should use EC2Instance class' do
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
+        expect(audit_results.region).to eq("us-east")
       end
     end
 
     context '#instances?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.instances?).to eq(true)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => true, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.instances?).to eq(false)
       end
     end
 
     context '#reserved?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.reserved?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => true, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.reserved?).to eq(true)
       end
     end
 
     context '#all?' do
       it 'should return true' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.all?).to eq(false)
       end
 
       it 'should return true' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         expect(audit_results.all?).to eq(true)
       end
     end
 
     context '#gather_data' do
       it 'should gather some empty results by comparison' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -104,7 +123,8 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just instances' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq([])
@@ -112,7 +132,8 @@ module SportNginAwsAuditor
       end
 
       it 'should gather some empty results from just reserved' do
-        audit_results = AuditData.new(false, true, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => true, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         audit_results.gather_data
         expect(audit_results.data).to eq([@instance, @instance])
         expect(audit_results.retired_tags).to eq(nil)
@@ -122,7 +143,8 @@ module SportNginAwsAuditor
 
     context '#gather_instances_data' do
       it 'should gather some instances data but not convert' do
-        audit_results = AuditData.new(true, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => true, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         result1, result2 = audit_results.gather_instances_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
@@ -131,19 +153,12 @@ module SportNginAwsAuditor
 
     context '#gather_all_data' do
       it 'should gather some comparison data but not convert' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
+        info = {:instances => false, :reserved => false, :class => "EC2Instance", :tag_name => "no-reserved-instance", :regexes => @ignore_instances_regexes, :region => 'us-east-1'}
+        audit_results = AuditData.new(info)
         result1, result2, result3 = audit_results.gather_all_data
         expect(result1).to eq({'instance1' => 1, 'instance2' => 1})
         expect(result2).to eq([])
         expect(result3).to eq(@retired_ris)
-      end
-    end
-
-    context '#gather_region' do
-      it 'should gather the region from an instance' do
-        audit_results = AuditData.new(false, false, "EC2Instance", "no-reserved-instance", @ignore_instances_regexes)
-        audit_results.gather_region(@ec2_instances)
-        expect(audit_results.region).to eq('us-east')
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -11,14 +11,14 @@ module SportNginAwsAuditor
 
       it "should receive new Aws::SharedCredentials" do
         expect(Aws::SharedCredentials).to receive(:new).with(profile_name: 'staging')
-        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging')
       end
 
       it "should update configs" do
         coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
         allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
         expect(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
-        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging')
       end
     end
 
@@ -41,7 +41,7 @@ module SportNginAwsAuditor
 
         expect(Aws::Credentials).to receive(:new).and_return(cred_double).at_least(:once)
         expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
-        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging')
       end
     end
 
@@ -65,17 +65,17 @@ module SportNginAwsAuditor
 
       it "should update config" do
         expect(Aws.config).to receive(:update)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
       end
 
       it "should call for an STS client" do
         expect(Aws::STS::Client).to receive(:new)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
       end
 
       it "should call for some credentials" do
         expect(Aws::AssumeRoleCredentials).to receive(:new)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -58,24 +58,19 @@ module SportNginAwsAuditor
                                           secret_access_key: 'secret_access_key',
                                           session_token: 'session_token')
         new_creds = double('new_creds', credentials: cred_double)
-        sts = double('sts', get_session_token: new_creds)
-        allow(Aws::STS::Client).to receive(:new).and_return(sts)
+        @sts = double('sts', get_session_token: new_creds)
+        allow(Aws::STS::Client).to receive(:new).and_return(@sts)
         allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(cred_double)
       end
 
       it "should update config" do
         expect(Aws.config).to receive(:update)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
-      end
-
-      it "should call for an STS client" do
-        expect(Aws::STS::Client).to receive(:new)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', @sts)
       end
 
       it "should call for some credentials" do
         expect(Aws::AssumeRoleCredentials).to receive(:new)
-        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', @sts)
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -11,14 +11,14 @@ module SportNginAwsAuditor
 
       it "should receive new Aws::SharedCredentials" do
         expect(Aws::SharedCredentials).to receive(:new).with(profile_name: 'staging')
-        AWSSDK::authenticate('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
       end
 
       it "should update configs" do
         coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
         allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
         expect(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
-        AWSSDK::authenticate('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
       end
     end
 
@@ -41,14 +41,14 @@ module SportNginAwsAuditor
 
         expect(Aws::Credentials).to receive(:new).and_return(cred_double).at_least(:once)
         expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
-        AWSSDK::authenticate('staging', 'us-east-1')
+        AWSSDK::authenticate_with_iam('staging', 'us-east-1')
       end
     end
 
     context 'without mfa with roles' do
       it "should update configs" do
         expect(Aws.config).to receive(:update).with({region: 'us-east-1'})
-        AWSSDK::authenticate_with_roles('staging', 'us-east-1')
+        AWSSDK::update_aws_config({region: 'us-east-1'})
       end
     end
 
@@ -65,17 +65,17 @@ module SportNginAwsAuditor
 
       it "should update config" do
         expect(Aws.config).to receive(:update)
-        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
       end
 
       it "should call for an STS client" do
         expect(Aws::STS::Client).to receive(:new)
-        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
       end
 
       it "should call for some credentials" do
         expect(Aws::AssumeRoleCredentials).to receive(:new)
-        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+        AWSSDK::authenticate_with_assumed_roles('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -11,14 +11,14 @@ module SportNginAwsAuditor
 
       it "should receive new Aws::SharedCredentials" do
         expect(Aws::SharedCredentials).to receive(:new).with(profile_name: 'staging')
-        AWSSDK::authenticate('staging')
+        AWSSDK::authenticate('staging', 'us-east-1')
       end
 
       it "should update configs" do
         coffee_types = {:coffee => "cappuccino", :beans => "arabica"}
         allow(Aws::SharedCredentials).to receive(:new).and_return(coffee_types)
         expect(Aws.config).to receive(:update).with({region: 'us-east-1', credentials: coffee_types})
-        AWSSDK::authenticate('staging')
+        AWSSDK::authenticate('staging', 'us-east-1')
       end
     end
 
@@ -41,14 +41,41 @@ module SportNginAwsAuditor
 
         expect(Aws::Credentials).to receive(:new).and_return(cred_double).at_least(:once)
         expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
-        AWSSDK::authenticate('staging')
+        AWSSDK::authenticate('staging', 'us-east-1')
       end
     end
 
     context 'without mfa with roles' do
       it "should update configs" do
         expect(Aws.config).to receive(:update).with({region: 'us-east-1'})
-        AWSSDK::authenticate_with_roles('staging')
+        AWSSDK::authenticate_with_roles('staging', 'us-east-1')
+      end
+    end
+
+    context 'without mfa with multiple accounts' do
+      before :each do
+        cred_double = double('cred_hash', access_key_id: 'access_key_id',
+                                          secret_access_key: 'secret_access_key',
+                                          session_token: 'session_token')
+        new_creds = double('new_creds', credentials: cred_double)
+        sts = double('sts', get_session_token: new_creds)
+        allow(Aws::STS::Client).to receive(:new).and_return(sts)
+        allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(cred_double)
+      end
+
+      it "should update config" do
+        expect(Aws.config).to receive(:update)
+        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+      end
+
+      it "should call for an STS client" do
+        expect(Aws::STS::Client).to receive(:new)
+        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
+      end
+
+      it "should call for some credentials" do
+        expect(Aws::AssumeRoleCredentials).to receive(:new)
+        AWSSDK::authenticate_for_multiple_accounts('staging', '999999999999', 'CrossAccountAuditorAccess', 'us-east-1')
       end
     end
   end

--- a/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/cache_instance_spec.rb
@@ -7,6 +7,7 @@ module SportNginAwsAuditor
       identity = double('identity', account: 123456789)
       client = double('client', get_caller_identity: identity)
       allow(Aws::STS::Client).to receive(:new).and_return(client)
+      # @client = Aws::ElastiCache::Client.new(region: 'us-east-1')
     end
 
     after :each do
@@ -34,24 +35,23 @@ module SportNginAwsAuditor
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
         tags = double('tags', tag_list: [tag1, tag2])
-        cache_client = double('cache_client', describe_cache_clusters: cache_clusters, list_tags_for_resource: tags)
-        allow(CacheInstance).to receive(:cache).and_return(cache_client)
+        @cache_client = double('cache_client', describe_cache_clusters: cache_clusters, list_tags_for_resource: tags)
       end
 
       it "should make a cache_instance for each instance" do
-        instances = CacheInstance.get_instances("tag_name")
+        instances = CacheInstance.get_instances(@cache_client, "tag_name")
         expect(instances.first).to be_an_instance_of(CacheInstance)
         expect(instances.last).to be_an_instance_of(CacheInstance)
       end
 
       it "should return an array of cache_instances" do
-        instances = CacheInstance.get_instances("tag_name")
+        instances = CacheInstance.get_instances(@cache_client, "tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = CacheInstance.get_instances("tag_name")
+        instances = CacheInstance.get_instances(@cache_client, "tag_name")
         instance = instances.first
         expect(instance.id).to eq("job-queue-cluster")
         expect(instance.name).to eq("job-queue-cluster")
@@ -75,24 +75,23 @@ module SportNginAwsAuditor
                                                                      cache_node_count: 1,
                                                                      class: "Aws::ElastiCache::Types::ReservedCacheNode")
         reserved_cache_nodes = double('cache_cluster', reserved_cache_nodes: [reserved_cache_instance1, reserved_cache_instance2])
-        cache_client = double('cache_client', describe_reserved_cache_nodes: reserved_cache_nodes)
-        allow(CacheInstance).to receive(:cache).and_return(cache_client)
+        @cache_client = double('cache_client', describe_reserved_cache_nodes: reserved_cache_nodes)
       end
 
       it "should make a reserved_cache_instance for each instance" do
-        reserved_instances = CacheInstance.get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances(@cache_client)
         expect(reserved_instances.first).to be_an_instance_of(CacheInstance)
         expect(reserved_instances.last).to be_an_instance_of(CacheInstance)
       end
 
       it "should return an array of reserved_cache_instances" do
-        reserved_instances = CacheInstance.get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances(@cache_client)
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = CacheInstance.get_reserved_instances
+        reserved_instances = CacheInstance.get_reserved_instances(@cache_client)
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("job-queue-cluster")
         expect(reserved_instance.name).to eq("job-queue-cluster")
@@ -121,24 +120,23 @@ module SportNginAwsAuditor
                                                                                duration: 31536000)
           reserved_cache_nodes = double('cache_cluster', reserved_cache_nodes: [retired_reserved_cache_instance1,
                                                                                 retired_reserved_cache_instance2])
-          cache_client = double('cache_client', describe_reserved_cache_nodes: reserved_cache_nodes)
-          allow(CacheInstance).to receive(:cache).and_return(cache_client)
+          @cache_client = double('cache_client', describe_reserved_cache_nodes: reserved_cache_nodes)
         end
 
         it "should make a retired_reserved_cache_instance for each instance" do
-          retired_reserved_instances = CacheInstance.get_retired_reserved_instances
+          retired_reserved_instances = CacheInstance.get_retired_reserved_instances(@cache_client)
           expect(retired_reserved_instances.first).to be_an_instance_of(CacheInstance)
           expect(retired_reserved_instances.last).to be_an_instance_of(CacheInstance)
         end
 
         it "should return an array of retired_reserved_cache_instances" do
-          retired_reserved_instances = CacheInstance.get_retired_reserved_instances
+          retired_reserved_instances = CacheInstance.get_retired_reserved_instances(@cache_client)
           expect(retired_reserved_instances).not_to be_empty
           expect(retired_reserved_instances.length).to eq(2)
         end
 
         it "should have proper variables set" do
-          retired_reserved_instances = CacheInstance.get_retired_reserved_instances
+          retired_reserved_instances = CacheInstance.get_retired_reserved_instances(@cache_client)
           retired_reserved_instance = retired_reserved_instances.first
           expect(retired_reserved_instance.id).to eq("job-queue-cluster")
           expect(retired_reserved_instance.name).to eq("job-queue-cluster")
@@ -162,9 +160,8 @@ module SportNginAwsAuditor
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
         tags = double('tags', tag_list: [tag1, tag2])
-        cache_client = double('cache_client', describe_cache_clusters: cache_clusters, list_tags_for_resource: tags)
-        allow(CacheInstance).to receive(:cache).and_return(cache_client)
-        instances = CacheInstance.get_instances("tag_name")
+        @cache_client = double('cache_client', describe_cache_clusters: cache_clusters, list_tags_for_resource: tags)
+        instances = CacheInstance.get_instances(@cache_client, "tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("Redis cache.t2.small")
       end

--- a/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/ec2_instance_spec.rb
@@ -38,24 +38,23 @@ module SportNginAwsAuditor
         name_tag = { key: "Name", value: "our-app-instance-100" }
         stack_tag = { key: "opsworks:stack", value: "our_app_service_2" }
         client_tags = double('tags', tags: [name_tag, stack_tag])
-        ec2_client = double('ec2_client', describe_instances: ec2_instances, describe_tags: client_tags)
-        allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
+        @ec2_client = double('@ec2_client', describe_instances: ec2_instances, describe_tags: client_tags)
       end
 
       it "should make an ec2_instance for each instance" do
-        instances = EC2Instance.get_instances("tag_name")
+        instances = EC2Instance.get_instances(@ec2_client, "tag_name")
         expect(instances.first).to be_an_instance_of(EC2Instance)
         expect(instances.last).to be_an_instance_of(EC2Instance)
       end
 
       it "should return an array of ec2_instances" do
-        instances = EC2Instance.get_instances("tag_name")
+        instances = EC2Instance.get_instances(@ec2_client, "tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = EC2Instance.get_instances("tag_name")
+        instances = EC2Instance.get_instances(@ec2_client, "tag_name")
         instance = instances.first
         expect(instance.stack_name).to eq("our_app_service_2")
         expect(instance.name).to eq("our-app-instance-100")
@@ -66,7 +65,7 @@ module SportNginAwsAuditor
       end
 
       it "should recognize Windows vs. Linux" do
-        instances = EC2Instance.get_instances("tag_name")
+        instances = EC2Instance.get_instances(@ec2_client, "tag_name")
         instance1 = instances.first
         instance2 = instances.last
         expect(instance1.platform).to eq("Linux VPC")
@@ -93,24 +92,23 @@ module SportNginAwsAuditor
                                                                  scope: 'Availability Zone',
                                                                  class: "Aws::EC2::Types::ReservedInstances")
         reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [reserved_ec2_instance1, reserved_ec2_instance2])
-        ec2_client = double('ec2_client', describe_reserved_instances: reserved_ec2_instances)
-        allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
+        @ec2_client = double('@ec2_client', describe_reserved_instances: reserved_ec2_instances)
       end
 
       it "should make a reserved_ec2_instance for each instance" do
-        reserved_instances = EC2Instance.get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances(@ec2_client)
         expect(reserved_instances.first).to be_an_instance_of(EC2Instance)
         expect(reserved_instances.last).to be_an_instance_of(EC2Instance)
       end
 
       it "should return an array of reserved_ec2_instances" do
-        reserved_instances = EC2Instance.get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances(@ec2_client)
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = EC2Instance.get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances(@ec2_client)
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("12345-dfas-1234-asdf-thisisfake!!")
         expect(reserved_instance.platform).to eq("Windows VPC")
@@ -120,7 +118,7 @@ module SportNginAwsAuditor
       end
 
       it "should recognize Windows vs. Linux" do
-        reserved_instances = EC2Instance.get_reserved_instances
+        reserved_instances = EC2Instance.get_reserved_instances(@ec2_client)
         reserved_instance1 = reserved_instances.first
         reserved_instance2 = reserved_instances.last
         expect(reserved_instance1.platform).to eq("Windows VPC")
@@ -159,24 +157,23 @@ module SportNginAwsAuditor
           reserved_ec2_instances = double('reserved_ec2_instances', reserved_instances: [retired_reserved_ec2_instance1,
                                                                                          retired_reserved_ec2_instance2,
                                                                                          reserved_ec2_instance1])
-          ec2_client = double('ec2_client', describe_reserved_instances: reserved_ec2_instances)
-          allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
+          @ec2_client = double('@ec2_client', describe_reserved_instances: reserved_ec2_instances)
         end
 
         it "should make a retired_reserved_ec2_instance for each instance" do
-          retired_reserved_instances = EC2Instance.get_retired_reserved_instances
+          retired_reserved_instances = EC2Instance.get_retired_reserved_instances(@ec2_client)
           expect(retired_reserved_instances.first).to be_an_instance_of(EC2Instance)
           expect(retired_reserved_instances.last).to be_an_instance_of(EC2Instance)
         end
 
         it "should return an array of retired_reserved_ec2_instances" do
-          retired_reserved_instances = EC2Instance.get_retired_reserved_instances
+          retired_reserved_instances = EC2Instance.get_retired_reserved_instances(@ec2_client)
           expect(retired_reserved_instances).not_to be_empty
           expect(retired_reserved_instances.length).to eq(2)
         end
 
         it "should have proper variables set" do
-          retired_reserved_instances = EC2Instance.get_retired_reserved_instances
+          retired_reserved_instances = EC2Instance.get_retired_reserved_instances(@ec2_client)
           retired_reserved_instance = retired_reserved_instances.first
           expect(retired_reserved_instance.id).to eq("12345-dfas-1234-asdf-thisisfake!!")
           expect(retired_reserved_instance.platform).to eq("Windows VPC")
@@ -187,7 +184,7 @@ module SportNginAwsAuditor
         end
 
         it "should recognize Windows vs. Linux" do
-          retired_reserved_instances = EC2Instance.get_retired_reserved_instances
+          retired_reserved_instances = EC2Instance.get_retired_reserved_instances(@ec2_client)
           retired_reserved_instance1 = retired_reserved_instances.first
           retired_reserved_instance2 = retired_reserved_instances.last
           expect(retired_reserved_instance1.platform).to eq("Windows VPC")
@@ -217,9 +214,8 @@ module SportNginAwsAuditor
         name_tag = { key: "Name", value: "our-app-instance-100" }
         stack_tag = { key: "opsworks:stack", value: "our_app_service_2" }
         tags = double('tags', tags: [name_tag, stack_tag])
-        ec2_client = double('ec2_client', describe_instances: ec2_instances, describe_tags: tags)
-        allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
-        instances = EC2Instance.get_instances("tag_name")
+        @ec2_client = double('@ec2_client', describe_instances: ec2_instances, describe_tags: tags)
+        instances = EC2Instance.get_instances(@ec2_client, "tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("Linux VPC us-east-1d t2.large")
       end
@@ -250,25 +246,24 @@ module SportNginAwsAuditor
         name_tag = { key: "Name", value: "our-app-instance-100" }
         stack_tag = { key: "opsworks:stack", value: "our_app_service_2" }
         tags = double('tags', tags: [name_tag, stack_tag])
-        ec2_client = double('ec2_client', describe_instances: ec2_instances, describe_tags: tags)
-        allow(EC2Instance).to receive(:ec2).and_return(ec2_client)
+        @ec2_client = double('@ec2_client', describe_instances: ec2_instances, describe_tags: tags)
       end
 
       it "should return a hash where the first element's key is the opsworks:stack name of the instances" do
-        instances = EC2Instance.get_instances
-        buckets = EC2Instance.bucketize
+        instances = EC2Instance.get_instances(@ec2_client)
+        buckets = EC2Instance.bucketize(@ec2_client)
         expect(buckets.first.first).to eq("our_app_service_2")
       end
 
       it "should return a hash where the last element's key is the opsworks:stack name of the instances" do
-        instances = EC2Instance.get_instances
-        buckets = EC2Instance.bucketize
+        instances = EC2Instance.get_instances(@ec2_client)
+        buckets = EC2Instance.bucketize(@ec2_client)
         expect(buckets.last.first).to eq("our_app_service_2")
       end
 
       it "should return a hash where each element is a list of ec2_instances" do
-        instances = EC2Instance.get_instances
-        buckets = EC2Instance.bucketize
+        instances = EC2Instance.get_instances(@ec2_client)
+        buckets = EC2Instance.bucketize(@ec2_client)
         expect(buckets).not_to be_empty
         expect(buckets.length).to eq(1)
         expect(buckets.first.length).to eq(2)

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -36,24 +36,23 @@ module SportNginAwsAuditor
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
         tags = double('tags', tag_list: [tag1, tag2])
-        rds_client = double('rds_client', describe_db_instances: db_instances, list_tags_for_resource: tags)
-        allow(RDSInstance).to receive(:rds).and_return(rds_client)
+        @rds_client = double('@rds_client', describe_db_instances: db_instances, list_tags_for_resource: tags)
       end
 
       it "should make a rds_instance for each instance" do
-        instances = RDSInstance.get_instances("tag_name")
+        instances = RDSInstance.get_instances(@rds_client, "tag_name")
         expect(instances.first).to be_an_instance_of(RDSInstance)
         expect(instances.last).to be_an_instance_of(RDSInstance)
       end
 
       it "should return an array of rds_instances" do
-        instances = RDSInstance.get_instances("tag_name")
+        instances = RDSInstance.get_instances(@rds_client, "tag_name")
         expect(instances).not_to be_empty
         expect(instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        instances = RDSInstance.get_instances("tag_name")
+        instances = RDSInstance.get_instances(@rds_client, "tag_name")
         instance = instances.first
         expect(instance.id).to eq("our-service")
         expect(instance.multi_az).to eq("Single-AZ")
@@ -79,24 +78,23 @@ module SportNginAwsAuditor
                                                                  db_instance_count: 2,
                                                                  class: "Aws::RDS::Types::ReservedDBInstance")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance1, reserved_rds_instance2])
-        rds_client = double('rds_client', describe_reserved_db_instances: reserved_db_instances)
-        allow(RDSInstance).to receive(:rds).and_return(rds_client)
+        @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
       end
 
       it "should make a reserved_rds_instance for each instance" do
-        reserved_instances = RDSInstance.get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances(@rds_client)
         expect(reserved_instances.first).to be_an_instance_of(RDSInstance)
         expect(reserved_instances.last).to be_an_instance_of(RDSInstance)
       end
 
       it "should return an array of reserved_rds_instances" do
-        reserved_instances = RDSInstance.get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances(@rds_client)
         expect(reserved_instances).not_to be_empty
         expect(reserved_instances.length).to eq(2)
       end
 
       it "should have proper variables set" do
-        reserved_instances = RDSInstance.get_reserved_instances
+        reserved_instances = RDSInstance.get_reserved_instances(@rds_client)
         reserved_instance = reserved_instances.first
         expect(reserved_instance.id).to eq("555te4yy-1234-555c-5678-thisisafake!!")
         expect(reserved_instance.multi_az).to eq("Single-AZ")
@@ -127,24 +125,23 @@ module SportNginAwsAuditor
                                                                            duration: 31536000)
         reserved_db_instances = double('db_instances', reserved_db_instances: [retired_reserved_rds_instance1,
                                                                                retired_reserved_rds_instance2])
-        rds_client = double('rds_client', describe_reserved_db_instances: reserved_db_instances)
-        allow(RDSInstance).to receive(:rds).and_return(rds_client)
+        @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
         end
 
         it "should make a retired_reserved_rds_instance for each instance" do
-          retired_reserved_instances = RDSInstance.get_retired_reserved_instances
+          retired_reserved_instances = RDSInstance.get_retired_reserved_instances(@rds_client)
           expect(retired_reserved_instances.first).to be_an_instance_of(RDSInstance)
           expect(retired_reserved_instances.last).to be_an_instance_of(RDSInstance)
         end
 
         it "should return an array of retired_reserved_rds_instances" do
-          retired_reserved_instances = RDSInstance.get_retired_reserved_instances
+          retired_reserved_instances = RDSInstance.get_retired_reserved_instances(@rds_client)
           expect(retired_reserved_instances).not_to be_empty
           expect(retired_reserved_instances.length).to eq(2)
         end
 
         it "should have proper variables set" do
-          retired_reserved_instances = RDSInstance.get_retired_reserved_instances
+          retired_reserved_instances = RDSInstance.get_retired_reserved_instances(@rds_client)
           retired_reserved_instance = retired_reserved_instances.first
           expect(retired_reserved_instance.id).to eq("555te4yy-1234-555c-5678-thisisafake!!")
           expect(retired_reserved_instance.multi_az).to eq("Single-AZ")
@@ -165,9 +162,8 @@ module SportNginAwsAuditor
                                                                 db_instance_count: 3,
                                                                 class: "Aws::RDS::Types::ReservedDBInstance")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance])
-        rds_client = double('rds_client', describe_reserved_db_instances: reserved_db_instances)
-        allow(RDSInstance).to receive(:rds).and_return(rds_client)
-        reserved_instances = RDSInstance.get_reserved_instances
+        @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
+        reserved_instances = RDSInstance.get_reserved_instances(@rds_client)
         reserved_instance = reserved_instances.first
         expect(reserved_instance.to_s).to eq("MySQL Single-AZ db.t2.small")
       end
@@ -185,9 +181,8 @@ module SportNginAwsAuditor
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
         tags = double('tags', tag_list: [tag1, tag2])
-        rds_client = double('rds_client', describe_db_instances: db_instances, list_tags_for_resource: tags)
-        allow(RDSInstance).to receive(:rds).and_return(rds_client)
-        instances = RDSInstance.get_instances("tag_name")
+        @rds_client = double('@rds_client', describe_db_instances: db_instances, list_tags_for_resource: tags)
+        instances = RDSInstance.get_instances(@rds_client, "tag_name")
         instance = instances.first
         expect(instance.to_s).to eq("PostgreSQL Single-AZ db.t2.small")
       end

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'httparty'
   spec.add_dependency 'colorize'
+  spec.add_dependency 'rack', '~> 2.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'httparty'
   spec.add_dependency 'colorize'
-  spec.add_dependency 'rack', '~> 2.0.1'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Description and Impact
----------------------
We want to be able to audit multiple accounts in AWS (in different regions and under different names) with only needing to generate one secret access key and key id. Moreover, right now whatever server is running the audit is only capable of auditing that region in that account. Therefore, we want to be able to give that single account all of the permissions and access to audit other accounts. Therefore, we'll use AWS roles to give our main account access to others and we'll make multiple clients, one for each region we are auditing. The link about cross account roles is in the URLs section.

This PR will run all U.S. regions by default, or a list of specified regions. It also revamped the printing of both the terminal outputs and the Slack outputs. It now considers retired RIs/tags just like normal instances, and prints them in a similar looking format.

The PR also contains some major refactoring of the `audit.rb` script.

Deploy Plan
-----------
* `git checkout master`
* `git pull`
* `op accept-pull 31`
* `soyuz deploy`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html

QA Plan
-------
There are some new flags that are added in this PR. Now, the region can be passed in (the default is `us-east-1`). Also, there is a new option `assume_roles` which is what can be used if the auditor will be used cross account. If `assume_roles` is used, then the arn_id (the integers in the middle of the arn) must be passed in, as well as the role_name (default is `CrossAccountAuditorAccess`). Lastly, the environment when running this command would stay the same as it has been, but since that doesn't naturally reflect what is being audited when the auditor is run cross account, we've added a display option (if a new display name is not given, then it will print the environment).

Therefore, with all of this, you can run:
- [x] `bin/sport-ngin-aws-auditor --assume_roles --arn_id=999999999999 --display='New Account' audit [account]` to see the auditor print cross accounts and in multiple regions into the terminal
- [x] `bin/sport-ngin-aws-auditor --assume_roles --arn_id=999999999999 --display='New Account' audit --slack [account]` to see the auditor print cross accounts and in multiple regions into Slack
- [x] `bin/sport-ngin-aws-auditor --assume_roles --arn_id=999999999999 --display='New Account' --region='us-east-1, us-east-2' audit [account]` to see the auditor print cross accounts and in specified regions into the terminal
- [x]  Run the command without the `assume_roles` and `arn_id` and you will see the command continues to work as expected