### PR TITLE
Define availability zone as attribute for RDS object to avoid errors

### DIFF
--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -30,11 +30,12 @@ module SportNginAwsAuditor
       end
     end
 
-    attr_accessor :id, :name, :multi_az, :scope, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date
+    attr_accessor :id, :name, :multi_az, :scope, :instance_type, :engine, :count, :tag_value, :tag_reason, :expiration_date, :availability_zone
     def initialize(rds_instance, account_id=nil, tag_name=nil, client=nil)
       if rds_instance.class.to_s == "Aws::RDS::Types::ReservedDBInstance"
         self.id = rds_instance.reserved_db_instances_offering_id
         self.scope = nil
+        self.availability_zone = nil
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.product_description)
@@ -44,6 +45,7 @@ module SportNginAwsAuditor
         self.id = rds_instance.db_instance_identifier
         self.name = rds_instance.db_name
         self.scope = nil
+        self.availability_zone = rds_instance.availability_zone
         self.multi_az = rds_instance.multi_az ? "Multi-AZ" : "Single-AZ"
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.engine)

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -124,7 +124,7 @@ module SportNginAwsAuditor
           if tag.reason
             description ="#{prefix} #{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value} because #{tag.reason}\n"
           else
-            description = "#{prefix} #{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value}"
+            description = "#{prefix} #{tag.instance_name} (#{tag.instance_type}) retired on #{tag.value}\n"
           end
 
           @message << description.colorize(:color => color)

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -58,6 +58,7 @@ module SportNginAwsAuditor
         expect(instance.multi_az).to eq("Single-AZ")
         expect(instance.instance_type).to eq("db.t2.small")
         expect(instance.engine).to eq("MySQL")
+        expect(instance.availability_zone).to eq('us-east-1a')
       end
     end
 

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -101,6 +101,7 @@ module SportNginAwsAuditor
         expect(reserved_instance.multi_az).to eq("Single-AZ")
         expect(reserved_instance.instance_type).to eq("db.t2.small")
         expect(reserved_instance.engine).to eq("Oracle SE Two")
+        expect(reserved_instance.availability_zone).to eq(nil)
       end
 
       context "for retired_reserved_rds_instances" do


### PR DESCRIPTION
Description and Impact
----------------------
Like in `cache_instance.rb` and `ec2_instance.rb`, we need to define what `.availability_zone` should be for each object. The documentation (linked below) says what each RDS instance has, so we need to define those in ours so that when we call it on line 100 of `audit.rb`, the objects are ready.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
http://docs.aws.amazon.com/sdkforruby/api/Aws/RDS/Client.html

QA Plan
-------
- [x] Test the command on slack
- [x] Test the command via terminal