### PR TITLE
Patch MFA and assume roles on non-AWS host

### DIFF
--- a/lib/sport_ngin_aws_auditor/aws.rb
+++ b/lib/sport_ngin_aws_auditor/aws.rb
@@ -46,8 +46,9 @@ module SportNginAwsAuditor
       Aws::STS::Client.new(client_options).get_caller_identity.account
     end
 
-    def self.sts_for_instance
-      Aws::STS::Client.new(region: DEFAULT_REGION, credentials: Aws::InstanceProfileCredentials.new)
+    def self.sts
+      creds = Aws::SharedCredentials.new(profile_name: @environment).credentials || Aws::InstanceProfileCredentials.new
+      Aws::STS::Client.new(region: DEFAULT_REGION, credentials: creds)
     end
 
     def self.ec2(region=DEFAULT_REGION)
@@ -87,12 +88,12 @@ module SportNginAwsAuditor
     def self.auth_with_assumed_roles(arn_id, role_name)
       role_arn = "arn:aws:iam::#{arn_id}:role/#{role_name}"
       session_name = "auditor#{Time.now.to_i}"
-      @credentials = Aws::AssumeRoleCredentials.new(client: sts_for_instance, role_arn: role_arn, role_session_name: session_name)
+      @credentials = Aws::AssumeRoleCredentials.new(client: sts, role_arn: role_arn, role_session_name: session_name)
     end
 
     def self.get_session(mfa_token, mfa_serial_number)
       return @session if @session
-      @session = sts_for_instance.get_session_token(duration_seconds: 3600, serial_number: mfa_serial_number, token_code: mfa_token)
+      @session = sts.get_session_token(duration_seconds: 3600, serial_number: mfa_serial_number, token_code: mfa_token)
     end
 
   end

--- a/spec/sport_ngin_aws_auditor/aws_spec.rb
+++ b/spec/sport_ngin_aws_auditor/aws_spec.rb
@@ -45,7 +45,7 @@ module SportNginAwsAuditor
         allow(Aws::IAM::Client).to receive(:new).and_return(iam_client)
 
         expect(Aws::Credentials).to receive(:new).and_return(cred_double).at_least(:once)
-        expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
+        expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds).twice
         AWS.auth_with_iam
       end
     end
@@ -65,9 +65,13 @@ module SportNginAwsAuditor
                                           secret_access_key: 'secret_access_key',
                                           session_token: 'session_token')
         new_creds = double('new_creds', credentials: cred_double)
+        shared_credentials = double('shared_credentials', access_key_id: 'access_key_id',
+                                    secret_access_key: 'secret_access_key')
+        shared_creds = double('shared_creds', credentials: shared_credentials)
         @sts = double('sts', get_session_token: new_creds)
         allow(Aws::STS::Client).to receive(:new).and_return(@sts)
         allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(cred_double)
+        expect(Aws::SharedCredentials).to receive(:new).and_return(shared_creds)
       end
 
       it "should set credentials" do


### PR DESCRIPTION
What
----------------------
Change assume roles and mfa to use shared credentials file or aws instance profile for STS client.

Why
----------------------
It was broken when ran on non-AWS server instance.

QA Plan
-------
- [x] Verify assume roles works on non-AWS host.
- [x] Verify MFA works on non-AWS host.
- [x] Verify assume roles works on AWS instance.