### PR TITLE
Compare platforms of RDS and EC2 instances correctly

### DIFF
--- a/lib/sport_ngin_aws_auditor/audit_data.rb
+++ b/lib/sport_ngin_aws_auditor/audit_data.rb
@@ -65,7 +65,7 @@ module SportNginAwsAuditor
     def gather_all_data
       instances = self.klass.get_instances(self.client, tag_name)
       retired_tags = self.klass.get_retired_tags(instances)
-      instance_hash = self.klass.compare(instances, ignore_instances_regexes, self.client)
+      instance_hash = self.klass.compare(instances, ignore_instances_regexes, self.client, self.klass)
       retired_ris = self.klass.get_recent_retired_reserved_instances(self.client)
 
       return instance_hash, retired_tags, retired_ris

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -74,7 +74,7 @@ module SportNginAwsAuditor
 
     # Generates a name based on the RDS engine or product description
     def engine_helper(engine)
-      case engine.downcase
+      case
       when engine.downcase.include?('aurora')
         'Aurora'
       when engine.downcase.include?('mariadb')

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -75,29 +75,29 @@ module SportNginAwsAuditor
     # Generates a name based on the RDS engine or product description
     def engine_helper(engine)
       case engine.downcase
-      when 'aurora'
+      when engine.downcase.include?('aurora')
         'Aurora'
-      when 'mariadb'
+      when engine.downcase.include?('mariadb')
         'MariaDB'
-      when 'mysql'
+      when engine.downcase.include?('mysql')
         'MySQL'
-      when 'oracle-ee',     'oracle-ee(byol)'
+      when engine.downcase.include?('oracle-ee')
         'Oracle EE'
-      when 'oracle-se',     'oracle-se(byol)'
+      when engine.downcase.include?('oracle-se')
         'Oracle SE'
-      when 'oracle-se1',    'oracle-se1(li)'
+      when engine.downcase.include?('oracle-se1')
         'Oracle SE One'
-      when 'oracle-se2',    'oracle-se2 (byol)' # extra space required
+      when engine.downcase.include?('oracle-se2')
         'Oracle SE Two'
-      when 'postgres',      'postgresql'
+      when engine.downcase.include?('postgres')
         'PostgreSQL'
-      when 'sqlserver-ee',  'sqlserver-ee(li)'
+      when engine.downcase.include?('sqlserver-ee')
         'SQL Server EE'
-      when 'sqlserver-ex',  'sqlserver-ex(li)'
+      when engine.downcase.include?('sqlserver-ex')
         'SQL Server EX'
-      when 'sqlserver-se',  'sqlserver-se(byol)'
+      when engine.downcase.include?('sqlserver-se')
         'SQL Server SE'
-      when 'sqlserver-web', 'sqlserver-web(li)'
+      when engine.downcase.include?('sqlserver-web')
         'SQL Server Web'
       else
         'Unknown DB Engine'

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -83,12 +83,12 @@ module SportNginAwsAuditor
         'MySQL'
       when engine.downcase.include?('oracle-ee')
         'Oracle EE'
-      when engine.downcase.include?('oracle-se')
-        'Oracle SE'
       when engine.downcase.include?('oracle-se1')
         'Oracle SE One'
       when engine.downcase.include?('oracle-se2')
         'Oracle SE Two'
+      when engine.downcase.include?('oracle-se')
+        'Oracle SE'
       when engine.downcase.include?('postgres')
         'PostgreSQL'
       when engine.downcase.include?('sqlserver-ee')

--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -78,20 +78,20 @@ module SportNginAwsAuditor
 
       def self.say_instances
         @audit_results.data.each do |instance|
-          name = instance.type
+          name_type = instance.type
           count = instance.count
           color, rgb, prefix = color_chooser({:instance => instance, :retired_ri => false, :retired_tag => false})
           
           if instance.tagged?
             if instance.reason
-              description = "#{prefix} #{name}: (expiring on #{instance.tag_value} because #{instance.reason})\n"
+              description = "#{prefix} #{name_type}: (expiring on #{instance.tag_value} because #{instance.reason})\n"
             else
-              description = "#{prefix} #{name}: (expiring on #{instance.tag_value})\n"
+              description = "#{prefix} #{name_type}: (expiring on #{instance.tag_value})\n"
             end
           elsif instance.ignored?
-            description = "#{prefix} #{name}\n"
+            description = "#{prefix} #{name_type}\n"
           else
-            description = "#{prefix} #{name}: #{count}\n"
+            description = "#{prefix} #{name_type}: #{count}\n"
           end
 
           @message << description.colorize(:color => color)
@@ -159,20 +159,20 @@ module SportNginAwsAuditor
           @slack_message.attachments.push({"color" => "#32CD32", "text" => "All RIs are properly matched here!", "mrkdwn_in" => ["text"]})
         else
           data_array.each do |instance|
-            type = instance.type
+            name_type = instance.type
             count = instance.count
             color, rgb, prefix = color_chooser({:instance => instance, :retired_ri => false, :retired_tag => false})
 
             if instance.tagged?
               if instance.reason
-                text = "#{prefix} #{instance.name}: (expiring on #{instance.tag_value} because #{instance.reason})"
+                text = "#{prefix} #{name_type}: (expiring on #{instance.tag_value} because #{instance.reason})"
               else
-                text = "#{prefix} #{instance.name}: (expiring on #{instance.tag_value})"
+                text = "#{prefix} #{name_type}: (expiring on #{instance.tag_value})"
               end
             elsif instance.ignored?
-              text = "#{prefix} #{instance.name}"
+              text = "#{prefix} #{name_type}"
             else
-              text = "#{prefix} #{type}: #{count}"
+              text = "#{prefix} #{name_type}: #{count}"
             end
 
             @slack_message.attachments.push({"color" => rgb, "text" => text, "mrkdwn_in" => ["text"]})

--- a/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
+++ b/spec/sport_ngin_aws_auditor/instance_helper_spec.rb
@@ -135,7 +135,7 @@ module SportNginAwsAuditor
           ris_count = ris.has_key?(key) ? ris[key][:count] : 0
           differences[key] = {count: ris_count - instance_count, region_based: false}
         end
-        result = klass.add_region_ris_to_hash(@region_reserved_instances, differences)
+        result = klass.add_region_ris_to_hash(@region_reserved_instances, differences, "EC2")
         expect(differences).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 0, region_based: false},
                                    "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end
@@ -147,7 +147,7 @@ module SportNginAwsAuditor
         allow(@region_reserved_ec2_instance1).to receive(:count=)
         allow(@region_reserved_ec2_instance2).to receive(:count=)
         instance_hash = klass.instance_count_hash(@ec2_instances)
-        result = klass.add_region_ris_to_hash(@region_reserved_instances, instance_hash)
+        result = klass.add_region_ris_to_hash(@region_reserved_instances, instance_hash, "EC2")
         expect(instance_hash).to eq({"Linux VPC us-east-1b t2.small"=>{count: 0, region_based: false}, "Windows us-east-1b t2.medium"=>{count: 5, region_based: false},
                                      "Linux VPC  t2.small" => {count: 2, region_based: true}, "Windows  t2.medium" => {count: 4, region_based: true}})
       end


### PR DESCRIPTION
What
----------------------
Match RDS platforms correctly. Match EC2 classic platforms more accurately. Show more information when printing out tagged and ignored instances.

Deploy Plan
-----------
Merge in and make a new version. Push to rubygems.

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] Verify that RDS DBs add correctly by running the auditor on an account with RDS DBs that were previously inconsistent: `bundle exec bin/sport-ngin-aws-auditor audit [account-name]`
- [ ] Verify that EC2 classic RIs will logically cover all instances where the type of the instance includes the type of the RI
- [x] Verify that running the auditor printing to slack shows more information (including the name and type of instance), when the instance is tagged or ignored: `bundle exec bin/sport-ngin-aws-auditor --config="./slack_config.yml" audit --slack [account-name]`