### PR TITLE
Fix bug where using the auditor with a region more than 9 characters doesn't work

### DIFF
--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -37,6 +37,7 @@ module SportNginAwsAuditor
         self.engine = engine_helper(rds_instance.product_description)
         self.count = rds_instance.db_instance_count
         self.expiration_date = rds_instance.start_time + rds_instance.duration if rds_instance.state == 'retired'
+        arn = rds_instance.reserved_db_instance_id
       elsif rds_instance.class.to_s == "Aws::RDS::Types::DBInstance"
         self.id = rds_instance.db_instance_identifier
         self.name = rds_instance.db_name
@@ -46,11 +47,9 @@ module SportNginAwsAuditor
         self.instance_type = rds_instance.db_instance_class
         self.engine = engine_helper(rds_instance.engine)
         self.count = 1
+        arn = rds_instance.db_instance_arn
 
         if tag_name
-          region = get_region
-          arn = "arn:aws:rds:#{region}:#{account_id}:db:#{self.id}"
-
            # go through to see if the tag we're looking for is one of them
           client.list_tags_for_resource(resource_name: arn).tag_list.each do |tag|
             if tag.key == tag_name
@@ -65,13 +64,6 @@ module SportNginAwsAuditor
 
     def to_s
       "#{engine} #{multi_az} #{instance_type}"
-    end
-
-    def get_region
-      region = self.availability_zone.split(//)
-      region.pop
-      region = region.join
-      region == "Multiple" ? "us-east-1" : region
     end
 
     def no_reserved_instance_tag_value

--- a/lib/sport_ngin_aws_auditor/rds_instance.rb
+++ b/lib/sport_ngin_aws_auditor/rds_instance.rb
@@ -48,8 +48,7 @@ module SportNginAwsAuditor
         self.count = 1
 
         if tag_name
-          region = rds_instance.availability_zone.split(//).first(9).join
-          region = "us-east-1" if region == "Multiple"
+          region = get_region
           arn = "arn:aws:rds:#{region}:#{account_id}:db:#{self.id}"
 
            # go through to see if the tag we're looking for is one of them
@@ -66,6 +65,13 @@ module SportNginAwsAuditor
 
     def to_s
       "#{engine} #{multi_az} #{instance_type}"
+    end
+
+    def get_region
+      region = self.availability_zone.split(//)
+      region.pop
+      region = region.join
+      region == "Multiple" ? "us-east-1" : region
     end
 
     def no_reserved_instance_tag_value

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -24,7 +24,8 @@ module SportNginAwsAuditor
                                                engine: "mysql",
                                                availability_zone: "us-east-1a",
                                                class: "Aws::RDS::Types::DBInstance",
-                                               db_name: 'Example-instance-01')
+                                               db_name: 'Example-instance-01',
+                                               db_instance_arn: "arn_example")
         rds_instance2 = double('rds_instance', db_instance_identifier: "our-service",
                                                multi_az: false,
                                                db_instance_class: "db.m3.large",
@@ -32,7 +33,8 @@ module SportNginAwsAuditor
                                                engine: "mysql",
                                                availability_zone: "us-east-1a",
                                                class: "Aws::RDS::Types::DBInstance",
-                                               db_name: 'Example-instance-01')
+                                               db_name: 'Example-instance-01',
+                                               db_instance_arn: "arn_example")
         db_instances = double('db_instances', db_instances: [rds_instance1, rds_instance2])
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")
@@ -116,7 +118,8 @@ module SportNginAwsAuditor
                                                                            db_instance_count: 1,
                                                                            class: "Aws::RDS::Types::ReservedDBInstance",
                                                                            start_time: @time - 31536000,
-                                                                           duration: 31536000)
+                                                                           duration: 31536000,
+                                                                           reserved_db_instance_arn: "arn_example")
           retired_reserved_rds_instance2 = double('reserved_rds_instance', reserved_db_instances_offering_id: "555te4yy-1234-555c-5678-thisisafake!!",
                                                                            multi_az: false,
                                                                            db_instance_class: "db.m3.large",
@@ -125,7 +128,8 @@ module SportNginAwsAuditor
                                                                            db_instance_count: 2,
                                                                            class: "Aws::RDS::Types::ReservedDBInstance",
                                                                            start_time: @time - 31536000,
-                                                                           duration: 31536000)
+                                                                           duration: 31536000,
+                                                                           reserved_db_instance_arn: "arn_example")
         reserved_db_instances = double('db_instances', reserved_db_instances: [retired_reserved_rds_instance1,
                                                                                retired_reserved_rds_instance2])
         @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -73,14 +73,16 @@ module SportNginAwsAuditor
                                                                  state: "active",
                                                                  product_description: "oracle-se2 (byol)",
                                                                  db_instance_count: 1,
-                                                                 class: "Aws::RDS::Types::ReservedDBInstance")
+                                                                 class: "Aws::RDS::Types::ReservedDBInstance",
+                                                                 reserved_db_instance_id: "123")
         reserved_rds_instance2 = double('reserved_rds_instance', reserved_db_instances_offering_id: "555te4yy-1234-555c-5678-thisisafake!!",
                                                                  multi_az: false,
                                                                  db_instance_class: "db.m3.large",
                                                                  state: "active",
                                                                  product_description: "postgresql",
                                                                  db_instance_count: 2,
-                                                                 class: "Aws::RDS::Types::ReservedDBInstance")
+                                                                 class: "Aws::RDS::Types::ReservedDBInstance",
+                                                                 reserved_db_instance_id: "123")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance1, reserved_rds_instance2])
         @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
       end
@@ -183,7 +185,8 @@ module SportNginAwsAuditor
                                               engine: "postgres",
                                               availability_zone: "us-east-1a",
                                               class: "Aws::RDS::Types::DBInstance",
-                                              db_name: 'Example-instance-01')
+                                              db_name: 'Example-instance-01',
+                                              db_instance_arn: "arn_example")
         db_instances = double('db_instances', db_instances: [rds_instance])
         tag1 = double('tag', key: "cookie", value: "chocolate chip")
         tag2 = double('tag', key: "ice cream", value: "oreo")

--- a/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
+++ b/spec/sport_ngin_aws_auditor/rds_instance_spec.rb
@@ -121,7 +121,8 @@ module SportNginAwsAuditor
                                                                            class: "Aws::RDS::Types::ReservedDBInstance",
                                                                            start_time: @time - 31536000,
                                                                            duration: 31536000,
-                                                                           reserved_db_instance_arn: "arn_example")
+                                                                           reserved_db_instance_arn: "arn_example",
+                                                                           reserved_db_instance_id: "123")
           retired_reserved_rds_instance2 = double('reserved_rds_instance', reserved_db_instances_offering_id: "555te4yy-1234-555c-5678-thisisafake!!",
                                                                            multi_az: false,
                                                                            db_instance_class: "db.m3.large",
@@ -131,7 +132,8 @@ module SportNginAwsAuditor
                                                                            class: "Aws::RDS::Types::ReservedDBInstance",
                                                                            start_time: @time - 31536000,
                                                                            duration: 31536000,
-                                                                           reserved_db_instance_arn: "arn_example")
+                                                                           reserved_db_instance_arn: "arn_example",
+                                                                           reserved_db_instance_id: "123")
         reserved_db_instances = double('db_instances', reserved_db_instances: [retired_reserved_rds_instance1,
                                                                                retired_reserved_rds_instance2])
         @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
@@ -169,7 +171,8 @@ module SportNginAwsAuditor
                                                                 state: "active",
                                                                 product_description: "mysql",
                                                                 db_instance_count: 3,
-                                                                class: "Aws::RDS::Types::ReservedDBInstance")
+                                                                class: "Aws::RDS::Types::ReservedDBInstance",
+                                                                reserved_db_instance_id: "123")
         reserved_db_instances = double('db_instances', reserved_db_instances: [reserved_rds_instance])
         @rds_client = double('@rds_client', describe_reserved_db_instances: reserved_db_instances)
         reserved_instances = RDSInstance.get_reserved_instances(@rds_client)

--- a/sport_ngin_aws_auditor.gemspec
+++ b/sport_ngin_aws_auditor.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4.0"
+  spec.add_development_dependency "byebug"
+
 end


### PR DESCRIPTION
What
----------------------
When running the auditor on a region that is more than 9 characters ("us-east-1" is 9, but "ap-southeast-1" is not), it breaks because previously the auditor was looking for exactly 9 characters when finding the region.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
- [x] `GLI_DEBUG=true bundle exec bin/sport-ngin-aws-auditor --region longer-region audit account_name`