### PR TITLE
Fix bug where we accidentally call .empty? on a nil object

### DIFF
--- a/lib/sport_ngin_aws_auditor/scripts/audit.rb
+++ b/lib/sport_ngin_aws_auditor/scripts/audit.rb
@@ -45,7 +45,7 @@ module SportNginAwsAuditor
                                         :regexes => @ignore_instances_regexes, :region => region})
         @audit_results.gather_data
 
-        unless @audit_results.data.empty?
+        unless @audit_results.data.nil? || @audit_results.data.empty?
           add_instance_type_to_message(type)
           print_audit_results(region) if (type.last || @no_selection)
         end


### PR DESCRIPTION
What
----------------------
There is a bug where we accidentally call `.empty?` on a `nil` object. Fix that.

Deploy Plan
-----------
> Does Platform Operations need to know anything special about this deploy? Are migrations present?

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
> Links to bug tickets or user stories.

QA Plan
-------
Verify that `GLI_DEBUG=true bundle exec bin/sport-ngin-aws-auditor audit account_name` does not result in an error.