### PR TITLE
Fix incorrect RI counts for EC2 instances

### DIFF
--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -104,7 +104,9 @@ module SportNginAwsAuditor
 
       # Process each ri_group determined by instance_type and platform
       ri_group_arr.each do |ri_group|
-        target_instance_type, target_platform, ri_count = ri_group[:instance_type], ri_group[:platform], ri_group[:count]
+        target_instance_type = ri_group[:instance_type]
+        target_platform = ri_group[:platform]
+        ri_count = ri_group[:count]
         instances_left = differences.select do |k,v|
           # Ex: k,v = "Linux VPC us-east-1d t2.small", {:count=>-15, :region_based=>false}
           Regexp.new("^#{target_platform}.*#{target_instance_type}$") =~ k
@@ -136,7 +138,9 @@ module SportNginAwsAuditor
     private def group_ris_region(ris_region)
       ri_group_arr = []
       ris_region.each do |ec2_ri_obj|
-        selected_ri_group = ri_group_arr.select { |ri_group| ri_group[:instance_type] == ec2_ri_obj.instance_type && ri_group[:platform] == ec2_ri_obj.platform  }
+        selected_ri_group = ri_group_arr.select do |ri_group|
+          ri_group[:instance_type] == ec2_ri_obj.instance_type && ri_group[:platform] == ec2_ri_obj.platform
+        end
         if selected_ri_group.count == 1
           selected_ri_group = selected_ri_group.first
           selected_ri_group[:count] += ec2_ri_obj.count

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -114,7 +114,7 @@ module SportNginAwsAuditor
             # Ex: k,v = "Linux VPC us-east-1d t2.small", {:count=>15, :region_based=>false}
             Regexp.new("^#{target_platform}.*#{target_instance_type}$") =~ k
           end
-          
+
           actual_instances_count = actual_instances.reduce(0) do | previous_count, actual_instance |
             previous_count += actual_instance[1][:count]
           end
@@ -147,8 +147,7 @@ module SportNginAwsAuditor
     def compare(instances, ignore_instances_regexes, client, klass)
       ignored_instances, instances_with_tag, instance_hash = sort_through_instances(instances, ignore_instances_regexes)
       ris_region, ris_hash = sort_through_RIs(client)
-      # TODO: Refactor this `measure_differences` method so that it uses ris_region for ec2
-      # ris_region is empty for rds and cache, and ris_hash is empty for ec2
+      # ris_region is empty for rds and cache, and ris_hash is empty for ec2 (by default)
       differences = measure_differences(instance_hash, ris_hash, ris_region, klass)
       add_additional_data(ris_region, instances_with_tag, ignored_instances, differences, klass)
       differences

--- a/lib/sport_ngin_aws_auditor/instance_helper.rb
+++ b/lib/sport_ngin_aws_auditor/instance_helper.rb
@@ -108,7 +108,7 @@ module SportNginAwsAuditor
         instance_count = instance_hash.has_key?(key) ? instance_hash[key][:count] : 0
         ris_count = ris_hash.has_key?(key) ? ris_hash[key][:count] : 0
         # positive count => more ris, negative count => more instances
-        differences[key] = {:count => ris_count - instance_count, :region_based => false}
+        differences[key] = { count: ris_count - instance_count, region_based: false }
       end
 
       # Region-based RI calculation
@@ -129,24 +129,22 @@ module SportNginAwsAuditor
             previous_count += actual_instance[1][:count]
           end
 
-          if instances_left_count <= 0
-            # zone RIs >= actual instances
-            differences["#{target_platform} #{target_instance_type}"] = { :count => ri_count, :region_based => true }
-          else
-            # zone RIs < actual instances
+          if instances_left_count > 0
+            # Actual instances left > zone RIs
             # Use regional instances
-            instances_left.each do |k,v|
+            instances_left.each_value do |v|
               if ri_count >= -v[:count]
                 ri_count += v[:count]
                 v[:count] = 0
               else
-                v[:count] = ri_count + v[:count] # v[:count] is always negative
+                # No more RIs left
+                v[:count] = ri_count + v[:count]
                 ri_count = 0
                 break;
               end
             end
-            differences["#{target_platform} #{target_instance_type}"] = { :count => ri_count, :region_based => true }
           end
+          differences["#{target_platform} #{target_instance_type}"] = { count: ri_count, region_based: true }
         end
       end
       differences

--- a/lib/sport_ngin_aws_auditor/version.rb
+++ b/lib/sport_ngin_aws_auditor/version.rb
@@ -1,3 +1,3 @@
 module SportNginAwsAuditor
-  VERSION = "4.3.1"
+  VERSION = "4.3.2"
 end


### PR DESCRIPTION
What
----------------------
Major refactoring 🔧 of `lib/sport_ngin_aws_auditor/instance_helper.rb` module to fix incorrect RI counts for EC2 instances.

Why
----------------------
RI count reports are incorrect because `SportNginAwsAuditor::InstanceHelper#compare` miscalculates `differences` variable for EC2 instances.

Deploy Plan
-----------
Merge this PR and release a new version of gem `4.3.2`

Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithReservedDBInstances.html
https://aws.amazon.com/elasticache/reserved-cache-nodes/

QA Plan
-------
- [x] Make sure to clone this repo and run `bundle`
- [x] Run `bundle exec sport-ngin-aws-auditor audit [your-aws-account-name]` in the master branch
- [x] Run `bundle exec sport-ngin-aws-auditor audit [your-aws-account-name]` in this branch (`git checkout fix-incorrect-count `)
- [x] Check if those two results are different if an error was present
- [x] The returned RI information should match the actual instance information in your AWS account
